### PR TITLE
Added math library.

### DIFF
--- a/.github/workflows/linux-latest.yml
+++ b/.github/workflows/linux-latest.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         mode: [debug, release]
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
 
     steps:
@@ -29,7 +29,7 @@ jobs:
     
     - name: Build ${{ matrix.mode }}
       run: |
-        xmake f -m ${{ matrix.mode }} --build_tests=y -y
+        xmake f -m ${{ matrix.mode }} --arch=x86_64 --build_tests=y -y
         xmake
     
     - name: Run tests
@@ -40,10 +40,10 @@ jobs:
     - name: Prepare artifacts
       run: |
         mkdir ${{ matrix.mode }}-artifact
-        move bin/windows_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
+        mv bin/linux_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
     
     - uses: actions/upload-artifact@v4
       with:
-        name: FlashlightEngine_Windows_${{ matrix.mode }}_${{ github.run_id }}
+        name: FlashlightEngine_Linux_${{ matrix.mode }}_${{ github.run_id }}
         path: ${{ matrix.mode }}-artifact/
-      name: Upload debug artifacts
+      name: Upload artifacts

--- a/.github/workflows/linux-latest.yml
+++ b/.github/workflows/linux-latest.yml
@@ -1,4 +1,4 @@
-name: Windows build
+name: Linux build
 
 on:
   push:

--- a/.github/workflows/linux-latest.yml
+++ b/.github/workflows/linux-latest.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Prepare artifacts
       run: |
         mkdir ${{ matrix.mode }}-artifact
-        mv bin/linux_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
+        mv bin/linux_x86_64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
     
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/msys2-latest.yml
+++ b/.github/workflows/msys2-latest.yml
@@ -1,4 +1,4 @@
-name: Windows build
+name: MSys2 build
 
 on:
   push:

--- a/.github/workflows/msys2-latest.yml
+++ b/.github/workflows/msys2-latest.yml
@@ -13,14 +13,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        msystem: [mingw64]
         mode: [debug, release]
 
     runs-on: windows-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
 
+    defaults:
+      run:
+        shell: msys2 {0}
+
     steps:
     - uses: actions/checkout@v4
       name: Checkout repository
+
+    # Setup MinGW
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        install: base-devel git unzip p7zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-xmake
 
     - uses: xmake-io/github-action-setup-xmake@v1
       with:
@@ -29,7 +40,7 @@ jobs:
     
     - name: Build ${{ matrix.mode }}
       run: |
-        xmake f -m ${{ matrix.mode }} --build_tests=y -y
+        xmake f -m ${{ matrix.mode }} --arch=x86_64 --build_tests=y -y
         xmake
     
     - name: Run tests
@@ -40,10 +51,10 @@ jobs:
     - name: Prepare artifacts
       run: |
         mkdir ${{ matrix.mode }}-artifact
-        move bin/windows_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
+        move bin/mingw_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
     
     - uses: actions/upload-artifact@v4
       with:
-        name: FlashlightEngine_Windows_${{ matrix.mode }}_${{ github.run_id }}
+        name: FlashlightEngine_MSys2_${{ matrix.mode }}_${{ github.run_id }}
         path: ${{ matrix.mode }}-artifact/
       name: Upload debug artifacts

--- a/.github/workflows/msys2-latest.yml
+++ b/.github/workflows/msys2-latest.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Prepare artifacts
       run: |
         mkdir ${{ matrix.mode }}-artifact
-        move bin/mingw_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
+        mv bin/mingw_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
     
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/msys2-latest.yml
+++ b/.github/workflows/msys2-latest.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Prepare artifacts
       run: |
         mkdir ${{ matrix.mode }}-artifact
-        mv bin/mingw_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
+        mv bin/mingw_x86_64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
     
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -44,5 +44,5 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: FlashlightEngine_Windows_${{ matrix.mode }}_${{ github.run_id }}
-        path: $${ matrix.mode }}-artifact/
+        path: $${{ matrix.mode }}-artifact/
       name: Upload debug artifacts

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -39,10 +39,10 @@ jobs:
     - name: Prepare artifacts
       run: |
         mkdir ${{ matrix.mode }}-artifact
-        move bin/windows_x64_${{ matrix.mode }}/ $${ matrix.mode }}-artifact/
+        move bin/windows_x64_${{ matrix.mode }}/ ${{ matrix.mode }}-artifact/
     
     - uses: actions/upload-artifact@v4
       with:
         name: FlashlightEngine_Windows_${{ matrix.mode }}_${{ github.run_id }}
-        path: $${{ matrix.mode }}-artifact/
+        path: ${{ matrix.mode }}-artifact/
       name: Upload debug artifacts

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -39,10 +39,10 @@ jobs:
     - name: Prepare artifacts
       run: |
         mkdir ${{ matrix.mode }}-artifact
-        move bin/windows_x64_debug/ debug-artifact/
+        move bin/windows_x64_${{ matrix.mode }}/ $${ matrix.mode }}-artifact/
     
     - uses: actions/upload-artifact@v4
       with:
         name: FlashlightEngine_Windows_${{ matrix.mode }}_${{ github.run_id }}
-        path: debug-artifact/
+        path: $${ matrix.mode }}-artifact/
       name: Upload debug artifacts

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -1,0 +1,48 @@
+name: Windows build
+
+on:
+  push:
+  pull_request:
+    paths-ignore:
+      - README.md
+      - .gitignore
+      - LICENSDE
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        mode: [debug, release]
+
+    runs-on: windows-latest
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout repository
+
+    - uses: xmake-io/github-action-setup-xmake@v1
+      with:
+        xmake-version: latest
+      name: Install xmake
+    
+    - name: Build ${{ matrix.mode }}
+      run: |
+        xmake f -m ${{ matrix.mode }} --build_tests=y -y
+        xmake
+    
+    - name: Run tests
+      if: matrix.mode != 'release'
+      run: |
+        xmake run FlTests
+
+    - name: Prepare artifacts
+      run: |
+        mkdir ${{ matrix.mode }}-artifact
+        move bin/windows_x64_debug/ debug-artifact/
+    
+    - uses: actions/upload-artifact@v4
+      with:
+        name: FlashlightEngine_Windows_${{ matrix.mode }}_${{ github.run_id }}
+        path: debug-artifact/
+      name: Upload debug artifacts

--- a/Include/FlashlightEngine/Core/Assert.hpp
+++ b/Include/FlashlightEngine/Core/Assert.hpp
@@ -14,8 +14,9 @@
 #include <source_location>
 
 namespace Fl {
-    template <typename T, typename... Args>
-    void FlAssert(T expr, const std::string& error, const std::source_location& location = std::source_location::current());
+    template <typename T>
+    void FlAssert(T expr, const std::string& error,
+                  const std::source_location& location = std::source_location::current());
 }
 
 #include <FlashlightEngine/Core/Assert.inl>

--- a/Include/FlashlightEngine/Core/Assert.hpp
+++ b/Include/FlashlightEngine/Core/Assert.hpp
@@ -15,8 +15,7 @@
 
 namespace Fl {
     template <typename T>
-    void FlAssert(T expr, const std::string& error,
-                  const std::source_location& location = std::source_location::current());
+    constexpr void FlAssert(T expr, const std::string& error, const std::source_location& location = std::source_location::current());
 }
 
 #include <FlashlightEngine/Core/Assert.inl>

--- a/Include/FlashlightEngine/Core/Assert.inl
+++ b/Include/FlashlightEngine/Core/Assert.inl
@@ -7,7 +7,7 @@
 #include <cassert>
 
 namespace Fl {
-    template <typename T, typename... Args>
+    template <typename T>
     void FlAssert(T expr, const std::string& error, std::source_location& location) {
         if (!expr) {;
             spdlog::critical("{} (In {} at ({}:{}) in {})", error, location.file_name(), location.line(), location.column(),

--- a/Include/FlashlightEngine/Core/Assert.inl
+++ b/Include/FlashlightEngine/Core/Assert.inl
@@ -8,8 +8,8 @@
 
 namespace Fl {
     template <typename T>
-    void FlAssert(T expr, const std::string& error, std::source_location& location) {
-        if (!expr) {;
+    void FlAssert(T expr, const std::string& error, const std::source_location& location) {
+        if (!expr) {
             spdlog::critical("{} (In {} at ({}:{}) in {})", error, location.file_name(), location.line(), location.column(),
                              location.function_name());
 

--- a/Include/FlashlightEngine/Core/Assert.inl
+++ b/Include/FlashlightEngine/Core/Assert.inl
@@ -8,7 +8,7 @@
 
 namespace Fl {
     template <typename T>
-    void FlAssert(T expr, const std::string& error, const std::source_location& location) {
+    constexpr void FlAssert(T expr, const std::string& error, const std::source_location& location) {
         if (!expr) {
             spdlog::critical("{} (In {} at ({}:{}) in {})", error, location.file_name(), location.line(), location.column(),
                              location.function_name());

--- a/Include/FlashlightEngine/Core/Profiler.hpp
+++ b/Include/FlashlightEngine/Core/Profiler.hpp
@@ -24,7 +24,7 @@ void operator delete(void* ptr) noexcept;
 
 #else
 
-#define FL_PROFILE_SCOPE(name)
+#define FL_PROFILE(name)
 #define FL_PROFILER_FRAMEMARK
 
 #endif

--- a/Include/FlashlightEngine/Math/Angle.hpp
+++ b/Include/FlashlightEngine/Math/Angle.hpp
@@ -1,0 +1,331 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_MATH_ANGLE_HPP
+#define FL_MATH_ANGLE_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+#include <FlashlightEngine/Math/Constants.hpp>
+#include <FlashlightEngine/Math/FloatMath.hpp>
+
+namespace Fl {
+    template <typename T>
+    struct Degrees;
+
+    template <typename T>
+    struct Radians;
+
+    /**
+     * @brief Degrees class, handling mathematical angles in degrees.
+     * @tparam T Type of the degrees' value.
+     */
+    template <typename T>
+    struct Degrees {
+        static_assert(std::is_floating_point_v<T>, "[Error] Fl::Degrees' type must be floating-point.");
+
+        constexpr explicit Degrees(T val) noexcept;
+        constexpr explicit Degrees(Radians<T> rad) noexcept;
+        constexpr Degrees(const Degrees&) noexcept = default;
+        constexpr Degrees(Degrees&&) noexcept = default;
+
+        /**
+         * @brief Default copy assignment operator.
+         * @return Reference to the copied Fl::Degrees object.
+         */
+        constexpr Degrees& operator=(const Degrees&) noexcept = default;
+
+        /**
+         * @brief Default copy assignment operator.
+         * @return Reference to the copied Fl::Degrees object.
+         */
+        constexpr Degrees& operator=(Degrees&&) noexcept = default;
+
+        /**
+         * @brief Degrees negation operator.
+         * @return Negated degrees object.
+         */
+        constexpr Degrees operator-() const noexcept;
+
+        /**
+         * @brief Degrees-value addition operator.
+         * @tparam ValueType Type of the value to be added.
+         * @param val Value to be added.
+         * @return Result of the value added to the Degrees object.
+         */
+        template <typename ValueType>
+        constexpr Degrees operator+(ValueType val) const noexcept;
+
+        /**
+         * @brief Degrees-value subtraction operator.
+         * @tparam ValueType Type of the value to be subtracted.
+         * @param val Value to be subtracted.
+         * @return Result of the value subtracted to the Degrees object.
+         */
+        template <typename ValueType>
+        constexpr Degrees operator-(ValueType val) const noexcept;
+
+        /**
+         * @brief Degrees-value multiplication operator.
+         * @tparam ValueType Type of the value to be multiplied by.
+         * @param val Value to be multiplied by.
+         * @return Result of the Degrees object multiplied by the value.
+         */
+        template <typename ValueType>
+        constexpr Degrees operator*(ValueType val) const noexcept;
+
+        /**
+         * @brief Degrees-value division operator.
+         * @tparam ValueType Type of the value to be divided by.
+         * @param val Value to be divided by.
+         * @return Result of the Degrees object divided by the value.
+         */
+        template <typename ValueType>
+        constexpr Degrees operator/(ValueType val) const noexcept;
+
+        /**
+         * @brief Degrees-value addition assignment operator.
+         * @tparam ValueType Type of the value to be added.
+         * @param val Value to be added.
+         * @return Reference to the modified Degrees object.
+         */
+        template <typename ValueType>
+        constexpr Degrees& operator+=(ValueType val) const noexcept;
+
+        /**
+         * @brief Degrees-value subtraction assignment operator.
+         * @tparam ValueType Type of the value to be subtracted.
+         * @param val Value to be subtracted.
+         * @return Reference to the modified Degrees object.
+         */
+        template <typename ValueType>
+        constexpr Degrees& operator-=(ValueType val) const noexcept;
+
+        /**
+         * @brief Degrees-value multiplication assignment operator.
+         * @tparam ValueType Type of the value to be multiplied by.
+         * @param val Value to be multiplied by.
+         * @return Reference to the modified Degrees object.
+         */
+        template <typename ValueType>
+        constexpr Degrees& operator*=(ValueType val) const noexcept;
+
+        /**
+         * @brief Degrees-value division assignment operator.
+         * @tparam ValueType Type of the value to be divided by.
+         * @param val Value to be divided by.
+         * @return Reference to the modified Degrees object.
+         */
+        template <typename ValueType>
+        constexpr Degrees& operator/=(ValueType val) const noexcept;
+
+        /**
+         * @brief Checks if the current degrees angle is equal to another given one. Uses a near equality check to take
+         *        floating-point errors into account.
+         * @param deg Degrees object to be compared with.
+         * @return Whether both Degrees objects are nearly equal or not.
+         */
+        constexpr bool operator==(const Degrees& deg) const noexcept;
+
+        /**
+         * @brief Checks if the current degrees angle is not equal to another given one. Uses a near equality check to
+         *        take floating-point errors into account.
+         * @param deg Degrees object to be compared with.
+         * @return Whether both Degrees objects are not equal or if they are.
+         */
+        constexpr bool operator!=(const Degrees& deg) const noexcept;
+
+        /**
+         * @brief Implicit degrees' value type conversion operator.
+         * @tparam To Type to convert the value to.
+         * @return Degrees object of the new type.
+         */
+        template <typename To>
+        constexpr operator Degrees<To>() const noexcept;
+
+        /**
+         * @brief Implicit degrees to radians conversion operator.
+         * @tparam To Type to convert the value to.
+         * @return Radians object of the new type.
+         */
+        template <typename To>
+        constexpr operator Radians<To>() const noexcept;
+
+        T Value;
+    };
+
+    // Aliases
+
+    using Degreesf = Degrees<F32>;
+    using Degreesd = Degrees<F64>;
+    using Degreesld = Degrees<long double>;
+
+    /**
+     * @brief Radians class, handling mathematical angles in radians.
+     * @tparam T Type of the degrees' value.
+     */
+    template <typename T>
+    struct Radians {
+        static_assert(std::is_floating_point_v<T>, "[Error] Fl::Radians' type must be floating-point.");
+
+        constexpr explicit Radians(T val) noexcept;
+        constexpr explicit Radians(Degrees<T> deg) noexcept;
+        constexpr Radians(const Radians&) noexcept = default;
+        constexpr Radians(Radians&&) noexcept = default;
+
+        /**
+         * @brief Default copy assignment operator.
+         * @return Reference to the copied Fl::Radians object.
+         */
+        constexpr Radians& operator=(const Radians&) noexcept = default;
+
+        /**
+         * @brief Default copy assignment operator.
+         * @return Reference to the copied Fl::Radians object.
+         */
+        constexpr Radians& operator=(Radians&&) noexcept = default;
+
+        /**
+         * @brief Radians negation operator.
+         * @return Negated radians object.
+         */
+        constexpr Radians operator-() const noexcept;
+
+        /**
+         * @brief Radians-value addition operator.
+         * @tparam ValueType Type of the value to be added.
+         * @param val Value to be added.
+         * @return Result of the value added to the Radians object.
+         */
+        template <typename ValueType>
+        constexpr Radians operator+(ValueType val) const noexcept;
+
+        /**
+         * @brief Radians-value subtraction operator.
+         * @tparam ValueType Type of the value to be subtracted.
+         * @param val Value to be subtracted.
+         * @return Result of the value subtracted to the Radians object.
+         */
+        template <typename ValueType>
+        constexpr Radians operator-(ValueType val) const noexcept;
+
+        /**
+         * @brief Radians-value multiplication operator.
+         * @tparam ValueType Type of the value to be multiplied by.
+         * @param val Value to be multiplied by.
+         * @return Result of the Radians object multiplied by the value.
+         */
+        template <typename ValueType>
+        constexpr Radians operator*(ValueType val) const noexcept;
+
+        /**
+         * @brief Radians-value division operator.
+         * @tparam ValueType Type of the value to be divided by.
+         * @param val Value to be divided by.
+         * @return Result of the Radians object divided by the value.
+         */
+        template <typename ValueType>
+        constexpr Radians operator/(ValueType val) const noexcept;
+
+        /**
+         * @brief Radians-value addition assignment operator.
+         * @tparam ValueType Type of the value to be added.
+         * @param val Value to be added.
+         * @return Reference to the modified Radians object.
+         */
+        template <typename ValueType>
+        constexpr Radians& operator+=(ValueType val) const noexcept;
+
+        /**
+         * @brief Radians-value subtraction assignment operator.
+         * @tparam ValueType Type of the value to be subtracted.
+         * @param val Value to be subtracted.
+         * @return Reference to the modified Radians object.
+         */
+        template <typename ValueType>
+        constexpr Radians& operator-=(ValueType val) const noexcept;
+
+        /**
+         * @brief Radians-value multiplication assignment operator.
+         * @tparam ValueType Type of the value to be multiplied by.
+         * @param val Value to be multiplied by.
+         * @return Reference to the modified Radians object.
+         */
+        template <typename ValueType>
+        constexpr Radians& operator*=(ValueType val) const noexcept;
+
+        /**
+         * @brief Radians-value division assignment operator.
+         * @tparam ValueType Type of the value to be divided by.
+         * @param val Value to be divided by.
+         * @return Reference to the modified Radians object.
+         */
+        template <typename ValueType>
+        constexpr Radians& operator/=(ValueType val) const noexcept;
+
+        /**
+         * @brief Checks if the current radians angle is equal to another given one. Uses a near equality check to take
+         *        floating-point errors into account.
+         * @param rad Radians object to be compared with.
+         * @return Whether both Radians objects are nearly equal or not.
+         */
+        constexpr bool operator==(const Radians& rad) const noexcept;
+
+        /**
+         * @brief Checks if the current radians angle is not equal to another given one. Uses a near equality check to
+         *        take floating-point errors into account.
+         * @param rad Radians object to be compared with.
+         * @return Whether both Radians objects are not equal or if they are.
+         */
+        constexpr bool operator!=(const Radians& rad) const noexcept;
+
+        /**
+         * @brief Implicit radians' value type conversion operator.
+         * @tparam To Type to convert the value to.
+         * @return Radians object of the new type.
+         */
+        template <typename To>
+        constexpr operator Radians<To>() const noexcept;
+
+        /**
+         * @brief Implicit radians to degrees conversion operator.
+         * @tparam To Type to convert the value to.
+         * @return Degrees object of the new type.
+         */
+        template <typename To>
+        constexpr operator Degrees<To>() const noexcept;
+
+        T Value;
+    };
+
+    // Aliases
+
+    using Radiansf = Radians<F32>;
+    using Radiansd = Radians<F64>;
+    using Radiansld = Radians<long double>;
+
+    namespace Literals {
+        constexpr Degreesld operator ""_deg(const U64 val) noexcept {
+            return Degreesld(static_cast<long double>(val));
+        }
+
+        constexpr Degreesld operator ""_deg(const long double val) noexcept {
+            return Degreesld(val);
+        }
+
+        constexpr Radiansld operator ""_rad(const U64 val) noexcept {
+            return Radiansld(static_cast<long double>(val));
+        }
+
+        constexpr Radiansld operator ""_rad(const long double val) noexcept {
+            return Radiansld(val);
+        }
+    }
+}
+
+#include <FlashlightEngine/Math/Angle.inl>
+
+#endif // FL_MATH_ANGLE_HPP

--- a/Include/FlashlightEngine/Math/Angle.hpp
+++ b/Include/FlashlightEngine/Math/Angle.hpp
@@ -93,7 +93,7 @@ namespace Fl {
          * @return Reference to the modified Degrees object.
          */
         template <typename ValueType>
-        constexpr Degrees& operator+=(ValueType val) const noexcept;
+        constexpr Degrees& operator+=(ValueType val) noexcept;
 
         /**
          * @brief Degrees-value subtraction assignment operator.
@@ -102,7 +102,7 @@ namespace Fl {
          * @return Reference to the modified Degrees object.
          */
         template <typename ValueType>
-        constexpr Degrees& operator-=(ValueType val) const noexcept;
+        constexpr Degrees& operator-=(ValueType val) noexcept;
 
         /**
          * @brief Degrees-value multiplication assignment operator.
@@ -111,7 +111,7 @@ namespace Fl {
          * @return Reference to the modified Degrees object.
          */
         template <typename ValueType>
-        constexpr Degrees& operator*=(ValueType val) const noexcept;
+        constexpr Degrees& operator*=(ValueType val) noexcept;
 
         /**
          * @brief Degrees-value division assignment operator.
@@ -120,7 +120,7 @@ namespace Fl {
          * @return Reference to the modified Degrees object.
          */
         template <typename ValueType>
-        constexpr Degrees& operator/=(ValueType val) const noexcept;
+        constexpr Degrees& operator/=(ValueType val) noexcept;
 
         /**
          * @brief Checks if the current degrees angle is equal to another given one. Uses a near equality check to take
@@ -237,7 +237,7 @@ namespace Fl {
          * @return Reference to the modified Radians object.
          */
         template <typename ValueType>
-        constexpr Radians& operator+=(ValueType val) const noexcept;
+        constexpr Radians& operator+=(ValueType val) noexcept;
 
         /**
          * @brief Radians-value subtraction assignment operator.
@@ -246,7 +246,7 @@ namespace Fl {
          * @return Reference to the modified Radians object.
          */
         template <typename ValueType>
-        constexpr Radians& operator-=(ValueType val) const noexcept;
+        constexpr Radians& operator-=(ValueType val) noexcept;
 
         /**
          * @brief Radians-value multiplication assignment operator.
@@ -255,7 +255,7 @@ namespace Fl {
          * @return Reference to the modified Radians object.
          */
         template <typename ValueType>
-        constexpr Radians& operator*=(ValueType val) const noexcept;
+        constexpr Radians& operator*=(ValueType val) noexcept;
 
         /**
          * @brief Radians-value division assignment operator.
@@ -264,7 +264,7 @@ namespace Fl {
          * @return Reference to the modified Radians object.
          */
         template <typename ValueType>
-        constexpr Radians& operator/=(ValueType val) const noexcept;
+        constexpr Radians& operator/=(ValueType val) noexcept;
 
         /**
          * @brief Checks if the current radians angle is equal to another given one. Uses a near equality check to take

--- a/Include/FlashlightEngine/Math/Angle.hpp
+++ b/Include/FlashlightEngine/Math/Angle.hpp
@@ -308,7 +308,7 @@ namespace Fl {
     using Radiansld = Radians<long double>;
 
     namespace Literals {
-        constexpr Degreesld operator ""_deg(const U64 val) noexcept {
+        constexpr Degreesld operator ""_deg(const unsigned long long val) noexcept {
             return Degreesld(static_cast<long double>(val));
         }
 
@@ -316,7 +316,7 @@ namespace Fl {
             return Degreesld(val);
         }
 
-        constexpr Radiansld operator ""_rad(const U64 val) noexcept {
+        constexpr Radiansld operator ""_rad(const unsigned long long val) noexcept {
             return Radiansld(static_cast<long double>(val));
         }
 

--- a/Include/FlashlightEngine/Math/Angle.inl
+++ b/Include/FlashlightEngine/Math/Angle.inl
@@ -15,7 +15,7 @@ namespace Fl {
 
     template <typename T>
     constexpr Degrees<T>::Degrees(Radians<T> rad) noexcept
-        : Value{rad * Constants::RadToDegConstant<T>} {
+        : Value{rad.Value * Constants::RadToDegConstant<T>} {
     }
 
     template <typename T>
@@ -50,7 +50,7 @@ namespace Fl {
 
     template <typename T>
     template <typename ValueType>
-    constexpr Degrees<T>& Degrees<T>::operator+=(ValueType val) const noexcept {
+    constexpr Degrees<T>& Degrees<T>::operator+=(ValueType val) noexcept {
         Value += static_cast<T>(val);
 
         return *this;
@@ -58,7 +58,7 @@ namespace Fl {
 
     template <typename T>
     template <typename ValueType>
-    constexpr Degrees<T>& Degrees<T>::operator-=(ValueType val) const noexcept {
+    constexpr Degrees<T>& Degrees<T>::operator-=(ValueType val) noexcept {
         Value -= static_cast<T>(val);
 
         return *this;
@@ -66,7 +66,7 @@ namespace Fl {
 
     template <typename T>
     template <typename ValueType>
-    constexpr Degrees<T>& Degrees<T>::operator*=(ValueType val) const noexcept {
+    constexpr Degrees<T>& Degrees<T>::operator*=(ValueType val) noexcept {
         Value *= static_cast<T>(val);
 
         return *this;
@@ -74,9 +74,9 @@ namespace Fl {
 
     template <typename T>
     template <typename ValueType>
-    constexpr Degrees<T>& Degrees<T>::operator/=(ValueType val) const noexcept {
+    constexpr Degrees<T>& Degrees<T>::operator/=(ValueType val) noexcept {
         FlAssert(val != 0, "Cannot divide by 0.");
-        Value += static_cast<T>(val);
+        Value /= static_cast<T>(val);
 
         return *this;
     }
@@ -112,7 +112,7 @@ namespace Fl {
 
     template <typename T>
     constexpr Radians<T>::Radians(Degrees<T> deg) noexcept
-        : Value{deg * Constants::DegToRadConstant<T>} {
+        : Value{deg.Value * Constants::DegToRadConstant<T>} {
     }
 
     template <typename T>
@@ -147,7 +147,7 @@ namespace Fl {
 
     template <typename T>
     template <typename ValueType>
-    constexpr Radians<T>& Radians<T>::operator+=(ValueType val) const noexcept {
+    constexpr Radians<T>& Radians<T>::operator+=(ValueType val) noexcept {
         Value += static_cast<T>(val);
 
         return *this;
@@ -155,7 +155,7 @@ namespace Fl {
 
     template <typename T>
     template <typename ValueType>
-    constexpr Radians<T>& Radians<T>::operator-=(ValueType val) const noexcept {
+    constexpr Radians<T>& Radians<T>::operator-=(ValueType val) noexcept {
         Value -= static_cast<T>(val);
 
         return *this;
@@ -163,7 +163,7 @@ namespace Fl {
 
     template <typename T>
     template <typename ValueType>
-    constexpr Radians<T>& Radians<T>::operator*=(ValueType val) const noexcept {
+    constexpr Radians<T>& Radians<T>::operator*=(ValueType val) noexcept {
         Value *= static_cast<T>(val);
 
         return *this;
@@ -171,9 +171,9 @@ namespace Fl {
 
     template <typename T>
     template <typename ValueType>
-    constexpr Radians<T>& Radians<T>::operator/=(ValueType val) const noexcept {
+    constexpr Radians<T>& Radians<T>::operator/=(ValueType val) noexcept {
         FlAssert(val != 0, "Cannot divide by 0.");
-        Value += static_cast<T>(val);
+        Value /= static_cast<T>(val);
 
         return *this;
     }

--- a/Include/FlashlightEngine/Math/Angle.inl
+++ b/Include/FlashlightEngine/Math/Angle.inl
@@ -1,0 +1,203 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#include <FlashlightEngine/Core/Assert.hpp>
+
+namespace Fl {
+#pragma region Degrees
+    template <typename T>
+    constexpr Degrees<T>::Degrees(T val) noexcept
+        : Value{val} {
+    }
+
+    template <typename T>
+    constexpr Degrees<T>::Degrees(Radians<T> rad) noexcept
+        : Value{rad * Constants::RadToDegConstant<T>} {
+    }
+
+    template <typename T>
+    constexpr Degrees<T> Degrees<T>::operator-() const noexcept {
+        return Degrees(-Value);
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Degrees<T> Degrees<T>::operator+(ValueType val) const noexcept {
+        return Degrees(Value + static_cast<T>(val));
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Degrees<T> Degrees<T>::operator-(ValueType val) const noexcept {
+        return Degrees(Value - static_cast<T>(val));
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Degrees<T> Degrees<T>::operator*(ValueType val) const noexcept {
+        return Degrees(Value * static_cast<T>(val));
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Degrees<T> Degrees<T>::operator/(ValueType val) const noexcept {
+        FlAssert(val != 0, "Cannot divide by 0.");
+        return Degrees(Value / static_cast<T>(val));
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Degrees<T>& Degrees<T>::operator+=(ValueType val) const noexcept {
+        Value += static_cast<T>(val);
+
+        return *this;
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Degrees<T>& Degrees<T>::operator-=(ValueType val) const noexcept {
+        Value -= static_cast<T>(val);
+
+        return *this;
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Degrees<T>& Degrees<T>::operator*=(ValueType val) const noexcept {
+        Value *= static_cast<T>(val);
+
+        return *this;
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Degrees<T>& Degrees<T>::operator/=(ValueType val) const noexcept {
+        FlAssert(val != 0, "Cannot divide by 0.");
+        Value += static_cast<T>(val);
+
+        return *this;
+    }
+
+    template <typename T>
+    constexpr bool Degrees<T>::operator==(const Degrees& deg) const noexcept {
+        return FloatMath::AreNearlyEqual(Value, deg.Value);
+    }
+
+    template <typename T>
+    constexpr bool Degrees<T>::operator!=(const Degrees& deg) const noexcept {
+        return !(*this == deg);
+    }
+
+    template <typename T>
+    template <typename To>
+    constexpr Degrees<T>::operator Degrees<To>() const noexcept {
+        return Degrees<To>(static_cast<To>(Value));
+    }
+
+    template <typename T>
+    template <typename To>
+    constexpr Degrees<T>::operator Radians<To>() const noexcept {
+        return Radians<To>(Degrees<To>(static_cast<To>(Value)));
+    }
+#pragma endregion Degrees
+
+#pragma region Radians
+    template <typename T>
+    constexpr Radians<T>::Radians(T val) noexcept
+        : Value{val} {
+    }
+
+    template <typename T>
+    constexpr Radians<T>::Radians(Degrees<T> deg) noexcept
+        : Value{deg * Constants::DegToRadConstant<T>} {
+    }
+
+    template <typename T>
+    constexpr Radians<T> Radians<T>::operator-() const noexcept {
+        return Radians(-Value);
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Radians<T> Radians<T>::operator+(ValueType val) const noexcept {
+        return Radians(Value + static_cast<T>(val));
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Radians<T> Radians<T>::operator-(ValueType val) const noexcept {
+        return Radians(Value - static_cast<T>(val));
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Radians<T> Radians<T>::operator*(ValueType val) const noexcept {
+        return Radians(Value * static_cast<T>(val));
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Radians<T> Radians<T>::operator/(ValueType val) const noexcept {
+        FlAssert(val != 0, "Cannot divide by 0.");
+        return Radians(Value / static_cast<T>(val));
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Radians<T>& Radians<T>::operator+=(ValueType val) const noexcept {
+        Value += static_cast<T>(val);
+
+        return *this;
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Radians<T>& Radians<T>::operator-=(ValueType val) const noexcept {
+        Value -= static_cast<T>(val);
+
+        return *this;
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Radians<T>& Radians<T>::operator*=(ValueType val) const noexcept {
+        Value *= static_cast<T>(val);
+
+        return *this;
+    }
+
+    template <typename T>
+    template <typename ValueType>
+    constexpr Radians<T>& Radians<T>::operator/=(ValueType val) const noexcept {
+        FlAssert(val != 0, "Cannot divide by 0.");
+        Value += static_cast<T>(val);
+
+        return *this;
+    }
+
+    template <typename T>
+    constexpr bool Radians<T>::operator==(const Radians& rad) const noexcept {
+        return FloatMath::AreNearlyEqual(Value, rad.Value);
+    }
+
+    template <typename T>
+    constexpr bool Radians<T>::operator!=(const Radians& rad) const noexcept {
+        return !(*this == rad);
+    }
+
+    template <typename T>
+    template <typename To>
+    constexpr Radians<T>::operator Radians<To>() const noexcept {
+        return Radians<To>(static_cast<To>(Value));
+    }
+
+    template <typename T>
+    template <typename To>
+    constexpr Radians<T>::operator Degrees<To>() const noexcept {
+        return Degrees<To>(Radians<To>(static_cast<To>(Value)));
+    }
+#pragma endregion Radians
+}

--- a/Include/FlashlightEngine/Math/Constants.hpp
+++ b/Include/FlashlightEngine/Math/Constants.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_MATH_CONSTANT_HPP
+#define FL_MATH_CONSTANT_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+namespace Fl::Constants {
+    /**
+     * @brief The π constant.
+     * @tparam T Type of Pi.
+     */
+    template <typename T>
+    constexpr T Pi = static_cast<T>(3.14159265358979323846L);
+
+    /**
+     * @brief Constant to convert degrees to radians.
+     * @tparam T Type of the conversion constant.
+     */
+    template <typename T>
+    constexpr T DegToRadConstant = static_cast<T>(Pi<T> / 180);
+
+    /**
+     * @brief Constant to convert radians to degrees.
+     * @tparam T Type of the conversion constant.
+     */
+    template <typename T>
+    constexpr T RadToDegConstant = static_cast<T>(180 / Pi<T>);
+
+    /**
+     * @brief Golden ratio constant. Roughly equal to (1 + sqrt(5)) / 2.
+     * @tparam T Type of the golden ratio.
+     */
+    template <typename T>
+    constexpr T GoldenRatio = static_cast<T>(1.61803398874989484820L);
+}
+
+#endif // FL_MATH_CONSTANT_HPP

--- a/Include/FlashlightEngine/Math/FloatMath.hpp
+++ b/Include/FlashlightEngine/Math/FloatMath.hpp
@@ -1,0 +1,94 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_MATH_FLOATMATH_HPP
+#define FL_MATH_FLOATMATH_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+#include <algorithm>
+#include <limits>
+
+namespace Fl {
+    template <typename T, U64 Size>
+    class Vector;
+
+    template <typename T, U64 Width, U64 Height>
+    class Matrix;
+
+    template <typename T>
+    class Quaternion;
+
+    namespace FloatMath {
+        /**
+         * @brief Compares two floating point values to see if they are nearly equal or not.
+         * @tparam T Type of the two values to compare. Must be a floating point type.
+         * @tparam ToleranceType The type of the tolerance constant. Must be a floating point type.
+         * @param val1 The first value.
+         * @param val2 The second value.
+         * @param absoluteTolerance The tolerance to compare the value with.
+         * @return Whether the two values are nearly equal or not.
+         */
+        template <typename T, typename ToleranceType = T>
+        constexpr bool AreNearlyEqual(
+            T val1,
+            T val2,
+            ToleranceType absoluteTolerance = std::numeric_limits<ToleranceType>::epsilon()
+        ) noexcept;
+
+        /**
+         * @brief Compares two floating point vectors to see if they are nearly equal or not.
+         * @tparam T Type of the two vectors' values to compare. Must be a floating point type.
+         * @tparam ToleranceType The type of the tolerance constant. Must be a floating point type.
+         * @param vec1 The first vector.
+         * @param vec2 The second vector.
+         * @param absoluteTolerance The tolerance to compare the value with.
+         * @return Whether the two vectors are nearly equal or not.
+         */
+        template <typename T, U64 Size, typename ToleranceType = T>
+        constexpr bool AreNearlyEqual(
+            Vector<T, Size> vec1,
+            Vector<T, Size> vec2,
+            ToleranceType absoluteTolerance = std::numeric_limits<ToleranceType>::epsilon()
+        ) noexcept;
+
+        /**
+         * @brief Compares two floating point matrices to see if they are nearly equal or not.
+         * @tparam T Type of the two matrices' values to compare. Must be a floating point type.
+         * @tparam ToleranceType The type of the tolerance constant. Must be a floating point type.
+         * @param mat1 The first matrix.
+         * @param mat2 The second matrix.
+         * @param absoluteTolerance The tolerance to compare the value with.
+         * @return Whether the two matrices are nearly equal or not.
+         */
+        template <typename T, U64 Width, U64 Height, typename ToleranceType = T>
+        constexpr bool AreNearlyEqual(
+            Matrix<T, Width, Height> mat1,
+            Matrix<T, Width, Height> mat2,
+            ToleranceType absoluteTolerance = std::numeric_limits<ToleranceType>::epsilon()
+        ) noexcept;
+
+        /**
+         * @brief Compares two floating point quaternions to see if they are nearly equal or not.
+         * @tparam T Type of the two quaternions' values to compare. Must be a floating point type.
+         * @tparam ToleranceType The type of the tolerance constant. Must be a floating point type.
+         * @param quat1 The first quaternion.
+         * @param quat2 The second quaternion.
+         * @param absoluteTolerance The tolerance to compare the value with.
+         * @return Whether the two quaternions are nearly equal or not.
+         */
+        template <typename T, typename ToleranceType = T>
+        constexpr bool AreNearlyEqual(
+            Quaternion<T> quat1,
+            Quaternion<T> quat2,
+            ToleranceType absoluteTolerance = std::numeric_limits<ToleranceType>::epsilon()
+        ) noexcept;
+    }
+}
+
+#include <FlashlightEngine/Math/FloatMath.inl>
+
+#endif // FL_MATH_FLOATMATH_HPP

--- a/Include/FlashlightEngine/Math/FloatMath.inl
+++ b/Include/FlashlightEngine/Math/FloatMath.inl
@@ -14,7 +14,7 @@ namespace Fl::FloatMath {
 
         const T absoluteDifference = std::abs(val1 - val2);
         return (absoluteDifference <= static_cast<T>(absoluteTolerance)
-            * std::max(static_cast<T>(1), std::max(std::abs(val1), std::max(val2)))
+            * std::max(static_cast<T>(1), std::max(std::abs(val1), std::abs(val2)))
         );
     }
 

--- a/Include/FlashlightEngine/Math/FloatMath.inl
+++ b/Include/FlashlightEngine/Math/FloatMath.inl
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#include <cmath>
+
+namespace Fl::FloatMath {
+    template <typename T, typename ToleranceType>
+    constexpr bool AreNearlyEqual(T val1, T val2, ToleranceType absoluteTolerance) noexcept {
+        static_assert(std::is_floating_point_v<T>, "[Error] T must be a floating point type.");
+        static_assert(std::is_floating_point_v<ToleranceType>, "[Error] ToleranceType must be a floating point type.");
+
+        const T absoluteDifference = std::abs(val1 - val2);
+        return (absoluteDifference <= static_cast<T>(absoluteTolerance)
+            * std::max(static_cast<T>(1), std::max(std::abs(val1), std::max(val2)))
+        );
+    }
+
+    template <typename T, U64 Size, typename ToleranceType>
+    constexpr bool AreNearlyEqual(
+        Vector<T, Size> vec1,
+        Vector<T, Size> vec2,
+        ToleranceType absoluteTolerance
+    ) noexcept {
+        for (U64 i = 0; i < Size; ++i) {
+            if (!AreNearlyEqual(vec1[i], vec2[i], absoluteTolerance)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    template <typename T, U64 Width, U64 Height, typename ToleranceType>
+    constexpr bool AreNearlyEqual(
+        Matrix<T, Width, Height> mat1,
+        Matrix<T, Width, Height> mat2,
+        ToleranceType absoluteTolerance
+    ) noexcept {
+        for (U64 i = 0; i < Width * Height; ++i) {
+            if (!AreNearlyEqual(mat1[i], mat2[i], absoluteTolerance)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    template <typename T, typename ToleranceType>
+    constexpr bool AreNearlyEqual(Quaternion<T> quat1, Quaternion<T> quat2, ToleranceType absoluteTolerance) noexcept {
+        if (!AreNearlyEqual(quat1.W(), quat2.W(), absoluteTolerance) ||
+            !AreNearlyEqual(quat1.X(), quat2.X(), absoluteTolerance) ||
+            !AreNearlyEqual(quat1.Y(), quat2.Y(), absoluteTolerance) ||
+            !AreNearlyEqual(quat1.Z(), quat2.Z(), absoluteTolerance)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Include/FlashlightEngine/Math/Matrix.hpp
+++ b/Include/FlashlightEngine/Math/Matrix.hpp
@@ -1,0 +1,440 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_MATH_MATRIX_HPP
+#define FL_MATH_MATRIX_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+#include <array>
+#include <ostream>
+
+namespace Fl {
+    template <typename T, U64 Width, U64 Height>
+    class Matrix;
+
+    template <typename T, U64 Size>
+    class Vector;
+
+    template <typename T, U64 Width, U64 Height>
+    std::ostream& operator<<(std::ostream& stream, const Matrix<T, Width, Height>& mat);
+
+    /**
+     * @brief Matrix class, representing a mathematical matrix, with generic type and size.
+     * @tparam T Type of the matrix's data.
+     * @tparam Width Matrix's width.
+     * @tparam Height Matrix's height;
+     */
+    template <typename T, U64 Width, U64 Height>
+    class Matrix {
+    public:
+        constexpr Matrix() noexcept = default;
+        constexpr explicit Matrix(const Matrix<T, Width + 1, Height + 1>& mat) noexcept;
+        constexpr explicit Matrix(const Matrix<T, Width - 1, Height - 1>& mat) noexcept;
+        /**
+         * @brief Constructs a matrix from the given values.
+         * @note All values must be of the same type as the matrix's inner one, and there must be exactly as many values
+         *       as the matrix can hold (width * height).
+         * @tparam From Type of the first value. Must be the same as T.
+         * @tparam Args Type of the other values. Must be the same as T.
+         * @param val First value.
+         * @param args other values.
+         */
+        template <typename From, typename... Args, typename = std::enable_if_t<std::is_same_v<std::decay_t<From>, T>>>
+        constexpr explicit Matrix(From&& val, Args&&... args) noexcept;
+        constexpr Matrix(const Matrix&) noexcept = default;
+        constexpr Matrix(Matrix&&) noexcept = default;
+
+        constexpr ~Matrix() noexcept = default;
+
+        [[nodiscard]] constexpr U64 GetWidth() const noexcept;
+        [[nodiscard]] constexpr U64 GetHeight() const noexcept;
+        constexpr const std::array<T, Width * Height>& GetData() const noexcept;
+        constexpr std::array<T, Width * Height>& GetData() noexcept;
+        constexpr const T* GetDataPtr() const noexcept;
+        constexpr T* GetDataPtr() noexcept;
+        /**
+         * @brief Gets an element given its width & height indices.
+         * @param widthIndex Element's width index.
+         * @param heightIndex Element's height index.
+         * @return A constant reference to the element.
+         */
+        constexpr const T& GetElement(U64 widthIndex, U64 heightIndex) const noexcept;
+        /**
+         * @brief Gets an element given its width & height indices.
+         * @param widthIndex Element's width index.
+         * @param heightIndex Element's height index.
+         * @return A reference to the element.
+         */
+        constexpr T& GetElement(U64 widthIndex, U64 heightIndex) noexcept;
+
+        /**
+         * @brief Creates an identity matrix; needs to be called with a square matrix type.
+         * @return Identity matrix.
+         */
+        static constexpr Matrix Identity() noexcept;
+        /**
+         * @brief Constructs a matrix from the given row vectors.
+         * @note All vectors must be of the same inner type as the matrix's, and must have a size equal to the matrix's
+         *       width.
+         * @tparam VectorTypes Types of the vectors to construct the matrix with.
+         * @param vecs Row vectors to construct the matrix with.
+         * @return A matrix with the given rows.
+         */
+        template <typename... VectorTypes>
+        static constexpr Matrix FromRows(VectorTypes&&... vecs) noexcept;
+        /**
+         * @brief Constructs a matrix from the given column vectors.
+         * @note All vectors must be of the same inner type as the matrix's, and must have a size equal to the matrix's
+         *       height.
+         * @tparam VectorTypes Types of the vectors to construct the matrix with.
+         * @param vecs Column vectors to construct the matrix with.
+         * @return A matrix with the given columns.
+         */
+        template <typename... VectorTypes>
+        static constexpr Matrix FromColumns(VectorTypes&&... vecs) noexcept;
+
+        /**
+         * @brief Transposes the current matrix.
+         * @return Transposed matrix.
+         */
+        constexpr Matrix<T, Height, Width> Transpose() const noexcept;
+        /**
+         * @brief Computes the matrix's determinant.
+         * @return Matrix's determinant.
+         */
+        constexpr T ComputeDeterminant() const noexcept;
+        /**
+         * @brief Computes the matrix's inverse.
+         * @return Matrix's inverse.
+         */
+        constexpr Matrix Inverse() const noexcept;
+        /**
+         * @brief Gets the values of the row at the given index.
+         * @param rowIndex Index of the row to retrieve.
+         * @return Vector containing the values of the requested row.
+         */
+        constexpr Vector<T, Width> GetRow(U64 rowIndex) const noexcept;
+        /**
+         * @brief Gets the values of the column at the given index.
+         * @param columnIndex Index of the column to retrieve.
+         * @return Vector containing the values of the requested column.
+         */
+        constexpr Vector<T, Height> GetColumn(U64 columnIndex) const noexcept;
+        /**
+         * @brief Checks for strict equality between the current matrix & the given one.
+         * @param mat Matrix to compare the current one to.
+         * @return Whether both matrices are strictly equal to each other or not.
+         */
+        [[nodiscard]] constexpr bool StrictlyEquals(const Matrix& mat) const noexcept;
+        /**
+         * @brief Computes the unique hash of the current matrix.
+         * @param seed Value to use as a hash seed.
+         * @return Matrix's hash.
+         */
+        [[nodiscard]] constexpr U64 Hash(U64 seed = 0) const noexcept;
+
+        /**
+         * @brief Default copy assignment operator.
+         * @return Reference to the copied matrix.
+         */
+        constexpr Matrix& operator=(const Matrix&) noexcept = default;
+        /**
+         * @brief Default move assignment operator.
+         * @return Reference to the moved matrix.
+         */
+        constexpr Matrix& operator=(Matrix&&) noexcept = default;
+        /**
+         * @brief Element-wise matrix-matrix addition operator.
+         * @param mat Matrix to be added.
+         * @return Result of the summed matrices.
+         */
+        constexpr Matrix operator+(const Matrix& mat) const noexcept;
+        /**
+         * @brief Element-wise matrix-value addition operator.
+         * @param val Value to be added.
+         * @return Result of the matrix summed with the value.
+         */
+        constexpr Matrix operator+(T val) const noexcept;
+        /**
+         * @brief Element-wise matrix-matrix subtraction operator.
+         * @param mat Matrix to be subtracted.
+         * @return Result of the subtracted matrices.
+         */
+        constexpr Matrix operator-(const Matrix& mat) const noexcept;
+        /**
+         * @brief Element-wise matrix-value subtraction operator.
+         * @param val Value to be subtracted.
+         * @return Result of the matrix subtracted by the value.
+         */
+        constexpr Matrix operator-(T val) const noexcept;
+        /**
+         * @brief Element-wise matrix-matrix multiplication operator.
+         * @param mat Matrix to be multiplied by.
+         * @return Result of the multiplied matrices.
+         */
+        constexpr Matrix operator%(const Matrix& mat) const noexcept;
+        /**
+         * @brief Element-wise matrix-value multiplication operator.
+         * @param val Value to be multiplied by.
+         * @return Result of the matrix multiplied by the value.
+         */
+        constexpr Matrix operator*(T val) const noexcept;
+        /**
+         * @brief Element-wise matrix-matrix division operator.
+         * @param mat Matrix to be divided by.
+         * @return Result of the divided matrices.
+         */
+        constexpr Matrix operator/(const Matrix& mat) const noexcept;
+        /**
+         * @brief Element-wise matrix-value division operator.
+         * @param val Value to be divided by.
+         * @return Result of the matrix divided by the value.
+         */
+        constexpr Matrix operator/(T val) const noexcept;
+        /**
+         * @brief Element-wise matrix-matrix addition assignment operator.
+         * @param mat Matrix to be added.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator+=(const Matrix& mat) noexcept;
+        /**
+         * @brief Element-wise matrix-value addition assignment operator.
+         * @param val Value to be added.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator+=(T val) noexcept;
+        /**
+         * @brief Element-wise matrix-matrix subtraction assignment operator.
+         * @param mat Matrix to be subtracted.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator-=(const Matrix& mat) noexcept;
+        /**
+         * @brief Element-wise matrix-value subtraction assignment operator.
+         * @param val Value to be subtracted.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator-=(T val) noexcept;
+        /**
+         * @brief Element-wise matrix-matrix multiplication assignment operator.
+         * @param mat Matrix to be multiplied by.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator%=(const Matrix& mat) noexcept;
+        /**
+         * @brief Element-wise matrix-value multiplication assignment operator.
+         * @param val Value to be multiplied by.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator*=(T val) noexcept;
+        /**
+         * @brief Element-wise matrix-matrix division assignment operator.
+         * @param mat Matrix to be divided by.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator/=(const Matrix& mat) noexcept;
+        /**
+         * @brief Element-wise matrix-value division assignment operator.
+         * @param val Value to be divided by.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator/=(T val) noexcept;
+        /**
+         * @brief Matrix-matrix multiplication assignment operator.
+         * @param mat Matrix to be multiplied by.
+         * @return Reference to the modified original matrix.
+         */
+        constexpr Matrix& operator*=(const Matrix& mat) noexcept;
+        /**
+         * @brief Element fetching operator with a single index.
+         * @warning Fl::Matrix uses a column-major layout, therefore this operator should be used with caution. For
+         *          example, for a 3x3 matrix, the indices are laid out as follows:
+         *
+         *          0 3 6
+         *          1 4 7
+         *          2 5 8
+         *
+         *          Prefer using @ref GetElement for better readability.
+         * @param index Element's index.
+         * @return Constant reference to the element.
+         */
+        constexpr const T& operator[](U64 index) const noexcept;
+        /**
+         * @brief Element fetching operator with a single index.
+         * @warning Fl::Matrix uses a column-major layout, therefore this operator should be used with caution. For
+         *          example, for a 3x3 matrix, the indices are laid out as follows:
+         *
+         *          0 3 6
+         *          1 4 7
+         *          2 5 8
+         *
+         *          Prefer using @ref GetElement for better readability.
+         * @param index Element's index.
+         * @return Reference to the element.
+         */
+        constexpr T& operator[](U64 index) noexcept;
+        /**
+         * @brief Matrix equality comparison operator. Uses a near-equality algorithm for floating-point values to take
+         *        floating point errors into account.
+         * @param mat Matrix to be compared with.
+         * @return Whether both matrices are nearly equal or not.
+         */
+        constexpr bool operator==(const Matrix& mat) const noexcept;
+        /**
+         * @brief Matrix inequality comparison operator. Uses a near-equality algorithm for floating-point values to
+         *        take floating point errors into account.
+         * @param mat Matrix to be compared with.
+         * @return Whether both matrices are unequal or not.
+         */
+        constexpr bool operator!=(const Matrix& mat) const noexcept;
+        /**
+         * @brief Output stream operator.
+         * @param stream Stream to output into.
+         * @param mat Matrix to be output.
+         * @return Reference to the modified stream.
+         */
+        friend std::ostream& operator<<<>(std::ostream& stream, const Matrix& mat);
+
+    private:
+        template <U64 WidthIndex, U64 HeightIndex, typename From, typename... Args>
+        constexpr void SetValues(From&& val, Args&&... args) noexcept;
+
+        template <typename VectorType, typename... VectorTypes>
+        constexpr void SetRows(VectorType&& vec, VectorTypes&&... vecs) noexcept;
+
+        template <typename VectorType, typename... VectorTypes>
+        constexpr void SetColumns(VectorType&& vec, VectorTypes&&... vecs) noexcept;
+
+        std::array<T, Width * Height> m_Data{};
+    };
+
+    /**
+     * @brief Matrix-matrix multiplication operator.
+     * @tparam T Type of the matrices' data.
+     * @tparam WidthLeft Type of the matrices' data.
+     * @tparam HeightLeft Height of the left-hand side matrix & width of the resulting one.
+     * @tparam WidthRight Width of the right-hand side matrix & height of the resulting one.
+     * @tparam HeightRight Height of the right-hand side matrix.
+     * @param mat1 Left-hand side matrix.
+     * @param mat2 Right-hand side matrix.
+     * @return Result of the multiplied matrices.
+     */
+    template <typename T, U64 WidthLeft, U64 HeightLeft, U64 WidthRight, U64 HeightRight>
+    constexpr Matrix<T, HeightLeft, WidthRight> operator*(const Matrix<T, WidthLeft, HeightLeft>& mat1,
+                                                          const Matrix<T, WidthRight, HeightRight>& mat2);
+
+    /**
+     * @brief Matrix-vector multiplication operator (assumes the vector to be vertical).
+     * @tparam T Type of the matrix's and vector's data.
+     * @tparam Width Width of the matrix and size of the vector.
+     * @tparam Height Height of the matrix and size of the resulting vector.
+     * @param mat Left-hand side matrix.
+     * @param vec Right-hand side vector.
+     * @return Result of the matrix-vector multiplication.
+     */
+    template <typename T, U64 Width, U64 Height>
+    constexpr Vector<T, Height> operator*(const Matrix<T, Width, Height>& mat, const Vector<T, Width>& vec);
+
+    /**
+     * @brief Matrix-vector multiplication operator (assumes the vector to be vertical).
+     * @tparam T Type of the matrix's and vector's data.
+     * @tparam Width Width of the matrix and size of the resulting vector.
+     * @tparam Height Height of the matrix and size of the vector.
+     * @param vec Left-hand side vector.
+     * @param mat Right-hand side matrix.
+     * @return Result of the matrix-vector multiplication.
+     */
+    template <typename T, U64 Width, U64 Height>
+    constexpr Vector<T, Width> operator*(const Vector<T, Height>& vec, const Matrix<T, Width, Height>& mat);
+
+    // Aliases
+
+    template <typename T>
+    using Mat2 = Matrix<T, 2, 2>;
+
+    template <typename T>
+    using Mat3 = Matrix<T, 3, 3>;
+
+    template <typename T>
+    using Mat4 = Matrix<T, 4, 4>;
+
+    using Mat2b = Mat2<U8>;
+    using Mat3b = Mat3<U8>;
+    using Mat4b = Mat4<U8>;
+
+    using Mat2i = Mat2<I32>;
+    using Mat3i = Mat3<I32>;
+    using Mat4i = Mat4<I32>;
+
+    using Mat2u = Mat2<U32>;
+    using Mat3u = Mat3<U32>;
+    using Mat4u = Mat4<U32>;
+
+    using Mat2f = Mat2<F32>;
+    using Mat3f = Mat3<F32>;
+    using Mat4f = Mat4<F32>;
+
+    using Mat2d = Mat2<F64>;
+    using Mat3d = Mat3<F64>;
+    using Mat4d = Mat4<F64>;
+}
+
+/**
+ * @brief Specialization of std::hash for @ref Fl::Matrix.
+ * @tparam T Type of the matrix's elements.
+ * @tparam Width Width of the matrix.
+ * @tparam Height Height of the matrix.
+ */
+template <typename T, Fl::U64 Width, Fl::U64 Height>
+struct std::hash<Fl::Matrix<T, Width, Height>> {
+    /**
+     * @brief Computes the hash of the given matrix.
+     * @param mat Matrix to compute the hash for.
+     * @return Matrix's hash value.
+     */
+    constexpr std::size_t operator()(const Fl::Matrix<T, Width, Height>& mat) const noexcept;
+};
+
+/**
+ * @brief Specialization of std::equal_to for @ref Fl::Matrix. This performs a strict equality check.
+ * @tparam T Type of the matrices' elements.
+ * @tparam Width Width of the matrices.
+ * @tparam Height Height of the matrices.
+ */
+template <typename T, Fl::U64 Width, Fl::U64 Height>
+struct std::equal_to<Fl::Matrix<T, Width, Height>> {
+    /**
+     * @brief Checks that the two given matrices are strictly equal to each other.
+     * @param mat1 First matrix to compare.
+     * @param mat2 Second matrix to compare.
+     * @return Whether both matrices are equal to each other or not.
+     */
+    constexpr std::size_t operator()(const Fl::Matrix<T, Width, Height>& mat1,
+                                     const Fl::Matrix<T, Width, Height>& mat2) const noexcept;
+};
+
+/**
+ * @brief Specialization of std::less for @ref Fl::Matrix.
+ * @tparam T Type of the matrices' elements.
+ * @tparam Width Width of the matrices.
+ * @tparam Height Height of the matrices.
+ */
+template <typename T, Fl::U64 Width, Fl::U64 Height>
+struct std::less<Fl::Matrix<T, Width, Height>> {
+    /**
+     * @brief Checks that the first given matrix is strictly less than the other.
+     * @param mat1 First matrix to compare.
+     * @param mat2 Second matrix to compare.
+     * @return Whether the first matrix is strictly less than the other or not.
+     */
+    constexpr bool operator()(const Fl::Matrix<T, Width, Height>& mat1,
+                              const Fl::Matrix<T, Width, Height>& mat2) const noexcept;
+};
+
+#include <FlashlightEngine/Math/Matrix.inl>
+
+#endif // FL_MATH_MATRIX_HPP

--- a/Include/FlashlightEngine/Math/Matrix.inl
+++ b/Include/FlashlightEngine/Math/Matrix.inl
@@ -1,0 +1,721 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#include <FlashlightEngine/Core/Assert.hpp>
+#include <FlashlightEngine/Math/FloatMath.hpp>
+
+#include <algorithm>
+
+
+namespace Fl {
+    namespace Detail {
+        // clang-format off
+        // @formatter:off
+        template <typename T>
+        constexpr T ComputeMatrixDeterminant(const Mat2<T>& mat) {
+            return (mat[0] * mat[3]) - (mat[2] * mat[1]);
+        }
+
+        template <typename T>
+        constexpr T ComputeMatrixDeterminant(const Mat3<T>& mat) {
+            const Mat2<T> leftMatrix(mat[4], mat[5],
+                                     mat[7], mat[8]);
+
+            const Mat2<T> centerMatrix(mat[3], mat[5],
+                                       mat[6], mat[8]);
+
+
+            const Mat2<T> rightMatrix(mat[3], mat[4],
+                                      mat[6], mat[7]);
+
+            return ComputeMatrixDeterminant(leftMatrix)   * mat[0]
+                 - ComputeMatrixDeterminant(centerMatrix) * mat[1]
+                 + ComputeMatrixDeterminant(rightMatrix)  * mat[2];
+        }
+
+        template <typename T>
+        constexpr T ComputeMatrixDeterminant(const Mat4<T>& mat) noexcept {
+            const Mat3<T> leftMatrix(mat[5],  mat[6],  mat[7],
+                                     mat[9],  mat[10], mat[11],
+                                     mat[13], mat[14], mat[15]);
+
+            const Mat3<T> centerLeftMatrix(mat[4],  mat[6],  mat[7],
+                                           mat[8],  mat[10], mat[11],
+                                           mat[12], mat[14], mat[15]);
+
+            const Mat3<T> centerRightMatrix(mat[4],  mat[5],  mat[7],
+                                            mat[8],  mat[9],  mat[11],
+                                            mat[12], mat[13], mat[15]);
+
+            const Mat3<T> rightMatrix(mat[4],  mat[5],  mat[6],
+                                      mat[8],  mat[9],  mat[10],
+                                      mat[12], mat[13], mat[14]);
+
+            return computeMatrixDeterminant(leftMatrix)        * mat[0]
+                 - computeMatrixDeterminant(centerLeftMatrix)  * mat[1]
+                 + computeMatrixDeterminant(centerRightMatrix) * mat[2]
+                 - computeMatrixDeterminant(rightMatrix)       * mat[3];
+        }
+
+        template <typename T>
+        constexpr Mat2<T> ComputeMatrixInverse(const Mat2<T>& mat, T invDeterminant) noexcept {
+            return Mat2<T>(
+                 mat[3] * invDeterminant, -mat[1] * invDeterminant,
+                -mat[2] * invDeterminant,  mat[0] * invDeterminant
+            );
+        }
+
+        template <typename T>
+        constexpr Mat3<T> ComputeMatrixInverse(const Mat3<T>& mat, T invDeterminant) noexcept {
+            const Mat2<T> topLeft(mat[4], mat[5],
+                                  mat[7], mat[8]);
+            const Mat2<T> topCenter(mat[3], mat[5],
+                                    mat[6], mat[8]);
+            const Mat2<T> topRight(mat[3], mat[4],
+                                   mat[6], mat[7]);
+
+            const Mat2<T> midLeft(mat[1], mat[2],
+                                  mat[7], mat[8]);
+            const Mat2<T> midCenter(mat[0], mat[2],
+                                    mat[6], mat[8]);
+            const Mat2<T> midRight(mat[0], mat[1],
+                                   mat[6], mat[7]);
+
+            const Mat2<T> botLeft(mat[1], mat[2],
+                                  mat[4], mat[5]);
+            const Mat2<T> botCenter(mat[0], mat[2],
+                                    mat[3], mat[5]);
+            const Mat2<T> botRight(mat[0], mat[1],
+                                   mat[3], mat[4]);
+
+            const Mat3<T> cofactors(
+                 topLeft.computeDeterminant(), -topCenter.computeDeterminant(),  topRight.computeDeterminant(),
+                -midLeft.computeDeterminant(),  midCenter.computeDeterminant(), -midRight.computeDeterminant(),
+                 botLeft.computeDeterminant(), -botCenter.computeDeterminant(),  botRight.computeDeterminant()
+            );
+
+            return cofactors * invDeterminant;
+        }
+
+        template <typename T>
+        constexpr Mat4<T> ComputeMatrixInverse(const Mat4<T>& mat, T invDeterminant) noexcept {
+            const Mat3<T> topLeft(mat[5],  mat[6],  mat[7],
+                                  mat[9],  mat[10], mat[11],
+                                  mat[13], mat[14], mat[15]);
+            const Mat3<T> topCenterLeft(mat[4],  mat[6],  mat[7],
+                                        mat[8],  mat[10], mat[11],
+                                        mat[12], mat[14], mat[15]);
+            const Mat3<T> topCenterRight(mat[4],  mat[5],  mat[7],
+                                         mat[8],  mat[9],  mat[11],
+                                         mat[12], mat[13], mat[15]);
+            const Mat3<T> topRight(mat[4],  mat[5],  mat[6],
+                                   mat[8],  mat[9],  mat[10],
+                                   mat[12], mat[13], mat[14]);
+
+            const Mat3<T> midTopLeft(mat[1],  mat[2],  mat[3],
+                                     mat[9],  mat[10], mat[11],
+                                     mat[13], mat[14], mat[15]);
+            const Mat3<T> midTopCenterLeft(mat[0],  mat[2],  mat[3],
+                                           mat[8],  mat[10], mat[11],
+                                           mat[12], mat[14], mat[15]);
+            const Mat3<T> midTopCenterRight(mat[0],  mat[1],  mat[3],
+                                            mat[8],  mat[9],  mat[11],
+                                            mat[12], mat[13], mat[15]);
+            const Mat3<T> midTopRight(mat[0],  mat[1],  mat[2],
+                                      mat[8],  mat[9],  mat[10],
+                                      mat[12], mat[13], mat[14]);
+
+            const Mat3<T> midBotLeft(mat[1],  mat[2],  mat[3],
+                                     mat[5],  mat[6],  mat[7],
+                                     mat[13], mat[14], mat[15]);
+            const Mat3<T> midBotCenterLeft(mat[0],  mat[2],  mat[3],
+                                           mat[4],  mat[6],  mat[7],
+                                           mat[12], mat[14], mat[15]);
+            const Mat3<T> midBotCenterRight(mat[0],  mat[1],  mat[3],
+                                            mat[4],  mat[5],  mat[7],
+                                            mat[12], mat[13], mat[15]);
+            const Mat3<T> midBotRight(mat[0],  mat[1],  mat[2],
+                                      mat[4],  mat[5],  mat[6],
+                                      mat[12], mat[13], mat[14]);
+
+            const Mat3<T> botLeft(mat[1], mat[2], mat[3],
+                                  mat[5], mat[6], mat[7],
+                                  mat[9], mat[10], mat[11]);
+            const Mat3<T> botCenterLeft(mat[0], mat[2], mat[3],
+                                        mat[4], mat[6], mat[7],
+                                        mat[8], mat[10], mat[11]);
+            const Mat3<T> botCenterRight(mat[0], mat[1], mat[3],
+                                         mat[4], mat[5], mat[7],
+                                         mat[8], mat[9], mat[11]);
+            const Mat3<T> botRight(mat[0], mat[1], mat[2],
+                                   mat[4], mat[5], mat[6],
+                                   mat[8], mat[9], mat[10]);
+
+            const T topLeftDeterm        = topLeft.ComputeDeterminant();
+            const T topCenterLeftDeterm  = topCenterLeft.ComputeDeterminant();
+            const T topCenterRightDeterm = topCenterRight.ComputeDeterminant();
+            const T topRightDeterm       = topRight.ComputeDeterminant();
+
+            const T midTopLeftDeterm        = midTopLeft.ComputeDeterminant();
+            const T midTopCenterLeftDeterm  = midTopCenterLeft.ComputeDeterminant();
+            const T midTopCenterRightDeterm = midTopCenterRight.ComputeDeterminant();
+            const T midTopRightDeterm       = midTopRight.ComputeDeterminant();
+
+            const T midBotLeftDeterm        = midBotLeft.ComputeDeterminant();
+            const T midBotCenterLeftDeterm  = midBotCenterLeft.ComputeDeterminant();
+            const T midBotCenterRightDeterm = midBotCenterRight.ComputeDeterminant();
+            const T midBotRightDeterm       = midBotRight.ComputeDeterminant();
+
+            const T botLeftDeterm           = botLeft.ComputeDeterminant();
+            const T botCenterLeftDeterm     = botCenterLeft.ComputeDeterminant();
+            const T botCenterRightDeterm    = botCenterRight.ComputeDeterminant();
+            const T botRightDeterm          = botRight.ComputeDeterminant();
+
+            const Mat4<T> cofactors(
+                 topLeftDeterm,     -topCenterLeftDeterm,     topCenterRightDeterm,    -topRightDeterm,
+                -midTopLeftDeterm,   midTopCenterLeftDeterm, -midTopCenterRightDeterm,  midTopRightDeterm,
+                 midBotLeftDeterm,  -midBotCenterLeftDeterm,  midBotCenterRightDeterm, -midBotRightDeterm,
+                -botLeftDeterm,      botCenterLeftDeterm,    -botCenterRightDeterm,     botRightDeterm
+            );
+
+            return cofactors * invDeterminant;
+        }
+        // @formatter:on
+        // clang-format on
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>::Matrix(const Matrix<T, Width + 1, Height + 1>& mat) noexcept {
+        U64 widthStride = 0;
+
+        for (U64 heightIndex = 0; heightIndex < Height; ++heightIndex) {
+            const U64 resultIndex = heightIndex * Width;
+
+            for (U64 widthIndex = 0; widthIndex < Width; ++widthIndex) {
+                const U64 finalIndex = resultIndex + widthIndex;
+
+                m_Data[finalIndex] = mat.m_Data[finalIndex + widthStride];
+            }
+
+            ++widthStride;
+        }
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>::Matrix(const Matrix<T, Width - 1, Height - 1>& mat) noexcept {
+        U64 heightStride = 0;
+
+        for (U64 widthIndex = 0; widthIndex < Width - 1; ++widthIndex) {
+            const U64 finalWidthIndex = widthIndex * (Height - 1);
+
+            for (U64 heightIndex = 0; heightIndex < Height - 1; ++heightIndex) {
+                const U64 finalIndex = finalWidthIndex + heightIndex;
+
+                m_Data[finalIndex + heightStride] = mat[finalIndex];
+            }
+
+            ++heightStride;
+        }
+
+        m_Data.back() = 1;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    template <typename From, typename... Args, typename>
+    constexpr Matrix<T, Width, Height>::Matrix(From&& val, Args&&... args) noexcept {
+        static_assert(sizeof...(Args) == Width * Height - 1,
+                      "[Error] A Fl::Matrix can't be constructed with more or less values than it can hold.");
+        SetValues<0, 0>(std::forward<From>(val), std::forward<Args>(args)...);
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr U64 Matrix<T, Width, Height>::GetWidth() const noexcept {
+        return Width;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr U64 Matrix<T, Width, Height>::GetHeight() const noexcept {
+        return Height;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr const std::array<T, Width * Height>& Matrix<T, Width, Height>::GetData() const noexcept {
+        return m_Data;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr std::array<T, Width * Height>& Matrix<T, Width, Height>::GetData() noexcept {
+        return m_Data;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr const T* Matrix<T, Width, Height>::GetDataPtr() const noexcept {
+        return m_Data.data();
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr T* Matrix<T, Width, Height>::GetDataPtr() noexcept {
+        return m_Data.data();
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr const T& Matrix<
+        T, Width, Height>::GetElement(const U64 widthIndex, const U64 heightIndex) const noexcept {
+        return m_Data[widthIndex * Height + heightIndex];
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr T& Matrix<T, Width, Height>::GetElement(const U64 widthIndex, const U64 heightIndex) noexcept {
+        return m_Data[widthIndex * Height + heightIndex];
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::Identity() noexcept {
+        static_assert(Width == Height, "[Error] Matrix must be square to be an identity matrix.");
+
+        Matrix result;
+
+        for (U64 diagIndex = 0; diagIndex < Width; ++diagIndex) {
+            result[diagIndex * Width + diagIndex] = static_cast<T>(1);
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    template <typename... VectorTypes>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::FromRows(VectorTypes&&... vecs) noexcept {
+        static_assert(sizeof...(vecs) == Height,
+                      "[Error] An Fl::Matrix cannot be constructed with more or less rows than it can hold.");
+
+        Matrix result;
+        result.SetRows(std::forward<VectorTypes>(vecs)...);
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    template <typename... VectorTypes>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::FromColumns(VectorTypes&&... vecs) noexcept {
+        static_assert(sizeof...(vecs) == Width,
+                      "[Error] An Fl::Matrix cannot be constructed with more or less columns than it can hold.");
+
+        Matrix result;
+        result.SetColumns(std::forward<VectorTypes>(vecs)...);
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Height, Width> Matrix<T, Width, Height>::Transpose() const noexcept {
+        Matrix<T, Height, Width> result;
+
+        for (U64 widthIndex = 0; widthIndex < Width; widthIndex++) {
+            const std::size_t finalWidthIndex = widthIndex * Height;
+
+            for (U64 heightIndex = 0; heightIndex < Height; heightIndex++) {
+                result[heightIndex * Width + widthIndex] = m_Data[finalWidthIndex + heightIndex];
+            }
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr T Matrix<T, Width, Height>::ComputeDeterminant() const noexcept {
+        static_assert(Width == Height, "[Error] Matrix must be a square one.");
+
+        return Detail::ComputeMatrixDeterminant(*this);
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::Inverse() const noexcept {
+        static_assert(Width == Height, "[Error] Matrix must be a square one.");
+
+        return Detail::ComputeMatrixInverse(*this);
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Vector<T, Width> Matrix<T, Width, Height>::GetRow(const U64 rowIndex) const noexcept {
+        FlAssert(rowIndex < Height, "Given row index is out of bound.");
+
+        Vector<T, Width> result;
+
+        for (U64 valIndex = 0; valIndex < Width; valIndex++) {
+            result[valIndex] = m_Data[rowIndex + valIndex * Height];
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Vector<T, Height> Matrix<T, Width, Height>::GetColumn(const U64 columnIndex) const noexcept {
+        FlAssert(columnIndex < Width, "Given column index is out of bound.");
+
+        Vector<T, Height> result;
+
+        const U64 columnBeginIndex = columnIndex * Height;
+
+        for (U64 valIndex = 0; valIndex < Height; valIndex++) {
+            result[valIndex] = m_Data[columnBeginIndex + valIndex];
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr bool Matrix<T, Width, Height>::StrictlyEquals(const Matrix& mat) const noexcept {
+        return std::equal(m_Data.cbegin(), m_Data.cend(), mat.GetData().cbegin());
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr U64 Matrix<T, Width, Height>::Hash(U64 seed) const noexcept {
+        std::hash<T> hasher{};
+
+        for (const T& element : m_Data) {
+            seed ^= hasher(element) + 0x9e3779b9 + (seed << 6u) + (seed >> 2u);
+        }
+
+        return seed;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::operator+(const Matrix& mat) const noexcept {
+        Matrix result = *this;
+
+        result += mat;
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::operator+(T val) const noexcept {
+        Matrix result = *this;
+
+        result += val;
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::operator-(const Matrix& mat) const noexcept {
+        Matrix result = *this;
+
+        result -= mat;
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::operator-(T val) const noexcept {
+        Matrix result = *this;
+
+        result -= val;
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::operator%(const Matrix& mat) const noexcept {
+        Matrix result = *this;
+
+        result %= mat;
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::operator*(T val) const noexcept {
+        Matrix result = *this;
+
+        result *= val;
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::operator/(const Matrix& mat) const noexcept {
+        Matrix result = *this;
+
+        result /= mat;
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::operator/(T val) const noexcept {
+        Matrix result = *this;
+
+        result /= val;
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator+=(const Matrix& mat) noexcept {
+        for (U64 i = 0; i < m_Data.size(); i++) {
+            m_Data[i] += mat[i];
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator+=(T val) noexcept {
+        for (T& element : m_Data) {
+            element += val;
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator-=(const Matrix& mat) noexcept {
+        for (U64 i = 0; i < m_Data.size(); i++) {
+            m_Data[i] -= mat[i];
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator-=(T val) noexcept {
+        for (T& element : m_Data) {
+            element -= val;
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator%=(const Matrix& mat) noexcept {
+        for (U64 i = 0; i < m_Data.size(); i++) {
+            m_Data[i] *= mat[i];
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator*=(T val) noexcept {
+        for (T& element : m_Data) {
+            element *= val;
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator/=(const Matrix& mat) noexcept {
+        for (U64 i = 0; i < m_Data.size(); i++) {
+            m_Data[i] /= mat[i];
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator/=(T val) noexcept {
+        for (T& element : m_Data) {
+            element /= val;
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Matrix<T, Width, Height>& Matrix<T, Width, Height>::operator*=(const Matrix& mat) noexcept {
+        *this = *this * mat;
+        return *this;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr const T& Matrix<T, Width, Height>::operator[](const U64 index) const noexcept {
+        return m_Data[index];
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr T& Matrix<T, Width, Height>::operator[](const U64 index) noexcept {
+        return m_Data[index];
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr bool Matrix<T, Width, Height>::operator==(const Matrix& mat) const noexcept {
+        if constexpr (std::is_floating_point_v<T>) {
+            return FloatMath::AreNearlyEqual(*this, mat);
+        }
+
+        return StrictlyEquals(mat);
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr bool Matrix<T, Width, Height>::operator!=(const Matrix& mat) const noexcept {
+        return !(*this == mat);
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    std::ostream& operator<<(std::ostream& stream, const Matrix<T, Width, Height>& mat) {
+        stream << '[';
+
+        for (U64 heightIndex = 0; heightIndex < Height; heightIndex++) {
+            if (heightIndex > 0) {
+                stream << ' ';
+            }
+
+            stream << "[ ";
+
+            for (U64 widthIndex = 0; widthIndex < Width; widthIndex++) {
+                stream << mat.GetElement(widthIndex, heightIndex);
+
+                if (widthIndex < Width - 1) {
+                    stream << ", ";
+                }
+            }
+
+            stream << " ]";
+
+            if (heightIndex < Height - 1) {
+                stream << '\n';
+            }
+        }
+
+        stream << ']';
+
+        return stream;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    template <U64 WidthIndex, U64 HeightIndex, typename From, typename... Args>
+    constexpr void Matrix<T, Width, Height>::SetValues(From&& val, Args&&... args) noexcept {
+        static_assert(std::is_same_v<T, std::decay_t<From>>,
+                      "[Error] An Fl::Matrix can only be constructed from values of the same type as its inner one.");
+
+        m_Data[WidthIndex * Height + HeightIndex] = std::forward<From>(val);
+
+        if constexpr (sizeof...(args) > 0) {
+            constexpr U64 newWidthIndex = (WidthIndex + 1) % Width;
+            SetValues<newWidthIndex, HeightIndex + (newWidthIndex == 0)>(std::forward<Args>(args)...);
+        }
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    template <typename VectorType, typename... VectorTypes>
+    constexpr void Matrix<T, Width, Height>::SetRows(VectorType&& vec, VectorTypes&&... vecs) noexcept {
+        static_assert(std::is_same_v<std::decay_t<VectorType>, Vector<T, Width>>,
+                      "[Error] Rows must all be vectors of the same type and size.");
+
+        constexpr U64 firstIndex = Height - sizeof...(vecs) - 1;
+
+        for (U64 widthIndex = 0; widthIndex < Width; ++widthIndex) {
+            m_Data[firstIndex + widthIndex * Height] = std::forward<VectorType>(vec)[widthIndex];
+        }
+
+        if constexpr (sizeof...(vecs) > 0) {
+            SetRows(std::forward<VectorTypes>(vecs)...);
+        }
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    template <typename VectorType, typename... VectorTypes>
+    constexpr void Matrix<T, Width, Height>::SetColumns(VectorType&& vec, VectorTypes&&... vecs) noexcept {
+        static_assert(std::is_same_v<std::decay_t<VectorType>, Vector<T, Height>>,
+                      "[Error] Columns must all be vectors of the same type and size.");
+
+        constexpr U64 firstIndex = Height * (Width - sizeof...(vecs) - 1);
+
+        for (U64 heightIndex = 0; heightIndex < Height; ++heightIndex) {
+            m_Data[firstIndex + heightIndex] = std::forward<VectorType>(vec)[heightIndex];
+        }
+
+        if constexpr (sizeof...(vecs) > 0) {
+            SetColumns(std::forward<VectorTypes>(vecs)...);
+        }
+    }
+
+    template <typename T, U64 WidthLeft, U64 HeightLeft, U64 WidthRight, U64 HeightRight>
+    constexpr Matrix<T, HeightLeft, WidthRight> operator*(const Matrix<T, WidthLeft, HeightLeft>& mat1,
+                                                          const Matrix<T, WidthRight, HeightRight>& mat2) {
+        static_assert(WidthLeft == HeightRight,
+                      "[Error] The left-hand side matrix's width must be equal to the right-hand side matrix's height.")
+            ;
+
+        Matrix<T, HeightLeft, WidthRight> result;
+
+        for (U64 widthIndex = 0; widthIndex < WidthRight; ++widthIndex) {
+            const U64 finalWidthIndex = widthIndex * HeightLeft;
+
+            for (U64 heightIndex = 0; heightIndex < HeightLeft; ++heightIndex) {
+                T& val = result[finalWidthIndex + heightIndex];
+
+                for (U64 stride = 0; stride < WidthLeft; ++stride) {
+                    val += mat1.GetElement(stride, heightIndex) * mat2.GetElement(widthIndex, stride);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Vector<T, Height> operator*(const Matrix<T, Width, Height>& mat, const Vector<T, Width>& vec) {
+        // This multiplication is made assuming the vector to be vertical.
+        Vector<T, Height> result;
+
+        for (U64 widthIndex = 0; widthIndex < Width; ++widthIndex) {
+            const U64 finalWidthIndex = widthIndex * Height;
+
+            for (U64 heightIndex = 0; heightIndex < Height; ++heightIndex) {
+                result[heightIndex] += mat[finalWidthIndex + heightIndex] * vec[widthIndex];
+            }
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Width, U64 Height>
+    constexpr Vector<T, Width> operator*(const Vector<T, Height>& vec, const Matrix<T, Width, Height>& mat) {
+        // This multiplication is made assuming the vector to be horizontal.
+        Vector<T, Width> result;
+
+        for (U64 widthIndex = 0; widthIndex < Width; ++widthIndex) {
+            const U64 finalWidthIndex = widthIndex * Height;
+
+            for (U64 heightIndex = 0; heightIndex < Height; ++heightIndex) {
+                result[widthIndex] += vec[heightIndex] * mat[finalWidthIndex + heightIndex];
+            }
+        }
+
+        return result;
+    }
+}
+
+// clang-format off
+// @formatter:off
+template <typename T, Fl::U64 Width, Fl::U64 Height>
+constexpr std::size_t std::hash<Fl::Matrix<T, Width, Height>>::operator()(const Fl::Matrix<T, Width, Height>& mat) const noexcept {
+    return mat.Hash();
+}
+
+template <typename T, Fl::U64 Width, Fl::U64 Height>
+constexpr std::size_t std::equal_to<Fl::Matrix<T, Width, Height>>::operator()(const Fl::Matrix<T, Width, Height>& mat1,
+                                                                              const Fl::Matrix<T, Width, Height>& mat2) const noexcept {
+    return mat1.StrictlyEquals(mat2);
+}
+
+template <typename T, Fl::U64 Width, Fl::U64 Height>
+constexpr bool std::less<Fl::Matrix<T, Width, Height>>::operator()(const Fl::Matrix<T, Width, Height>& mat1,
+                                                                   const Fl::Matrix<T, Width, Height>& mat2) const noexcept{
+    for (std::size_t i = 0; i < Width * Height; ++i) {
+        if (mat1[i] == mat2[i]) {
+            continue;
+        }
+
+        return (mat1[i] < mat2[i]);
+    }
+
+    return false;
+}
+
+// clang-format on
+// @formatter:on

--- a/Include/FlashlightEngine/Math/Matrix.inl
+++ b/Include/FlashlightEngine/Math/Matrix.inl
@@ -54,10 +54,10 @@ namespace Fl {
                                       mat[8],  mat[9],  mat[10],
                                       mat[12], mat[13], mat[14]);
 
-            return computeMatrixDeterminant(leftMatrix)        * mat[0]
-                 - computeMatrixDeterminant(centerLeftMatrix)  * mat[1]
-                 + computeMatrixDeterminant(centerRightMatrix) * mat[2]
-                 - computeMatrixDeterminant(rightMatrix)       * mat[3];
+            return ComputeMatrixDeterminant(leftMatrix)        * mat[0]
+                 - ComputeMatrixDeterminant(centerLeftMatrix)  * mat[1]
+                 + ComputeMatrixDeterminant(centerRightMatrix) * mat[2]
+                 - ComputeMatrixDeterminant(rightMatrix)       * mat[3];
         }
 
         template <typename T>
@@ -92,9 +92,9 @@ namespace Fl {
                                    mat[3], mat[4]);
 
             const Mat3<T> cofactors(
-                 topLeft.computeDeterminant(), -topCenter.computeDeterminant(),  topRight.computeDeterminant(),
-                -midLeft.computeDeterminant(),  midCenter.computeDeterminant(), -midRight.computeDeterminant(),
-                 botLeft.computeDeterminant(), -botCenter.computeDeterminant(),  botRight.computeDeterminant()
+                 topLeft.ComputeDeterminant(), -topCenter.ComputeDeterminant(),  topRight.ComputeDeterminant(),
+                -midLeft.ComputeDeterminant(),  midCenter.ComputeDeterminant(), -midRight.ComputeDeterminant(),
+                 botLeft.ComputeDeterminant(), -botCenter.ComputeDeterminant(),  botRight.ComputeDeterminant()
             );
 
             return cofactors * invDeterminant;
@@ -197,7 +197,7 @@ namespace Fl {
             for (U64 widthIndex = 0; widthIndex < Width; ++widthIndex) {
                 const U64 finalIndex = resultIndex + widthIndex;
 
-                m_Data[finalIndex] = mat.m_Data[finalIndex + widthStride];
+                m_Data[finalIndex] = mat[finalIndex + widthStride];
             }
 
             ++widthStride;
@@ -333,7 +333,13 @@ namespace Fl {
     constexpr Matrix<T, Width, Height> Matrix<T, Width, Height>::Inverse() const noexcept {
         static_assert(Width == Height, "[Error] Matrix must be a square one.");
 
-        return Detail::ComputeMatrixInverse(*this);
+        const T determinant = Detail::ComputeMatrixDeterminant(*this);
+
+        if (determinant == 0) {
+            return *this;
+        }
+
+        return Detail::ComputeMatrixInverse(*this, static_cast<T>(1) / determinant);
     }
 
     template <typename T, U64 Width, U64 Height>
@@ -544,9 +550,9 @@ namespace Fl {
     constexpr bool Matrix<T, Width, Height>::operator==(const Matrix& mat) const noexcept {
         if constexpr (std::is_floating_point_v<T>) {
             return FloatMath::AreNearlyEqual(*this, mat);
+        } else {
+            return StrictlyEquals(mat);
         }
-
-        return StrictlyEquals(mat);
     }
 
     template <typename T, U64 Width, U64 Height>

--- a/Include/FlashlightEngine/Math/Quaternion.hpp
+++ b/Include/FlashlightEngine/Math/Quaternion.hpp
@@ -1,0 +1,210 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_MATH_QUATERNION_HPP
+#define FL_MATH_QUATERNION_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+#include <FlashlightEngine/Math/Vector.hpp>
+
+namespace Fl {
+    template <typename T>
+    struct Degrees;
+
+    template <typename T>
+    struct Radians;
+
+    template <typename T, U64 Width, U64 Height>
+    class Matrix;
+
+    template <typename T>
+    using Mat4 = Matrix<T, 4, 4>;
+
+    template <typename T>
+    class Quaternion;
+
+    template <typename T>
+    std::ostream& operator<<(std::ostream& stream, const Quaternion<T>& quat);
+
+    /**
+     * @brief Quaternion representing a rotation in a 3D space. Quaternions are used to avoid [gimbal locks](https://en.wikipedia.org/wiki/Gimbal_lock)
+     *        present with Euler angles.
+     * @tparam T Type of the values held by the quaternion.
+     */
+    template <typename T>
+    class Quaternion {
+        static_assert(std::is_floating_point_v<T>, "[Error] Fl::Quaternion's type must be floating point.");
+
+    public:
+        constexpr Quaternion(T w, T x, T y, T z) noexcept;
+        constexpr Quaternion(Radians<T> angle, const Vec3<T>& axis) noexcept;
+        constexpr Quaternion(Radians<T> angle, T axisX, T axisY, T axisZ) noexcept;
+        constexpr Quaternion(const Quaternion&) noexcept = default;
+        constexpr Quaternion(Quaternion&&) noexcept = default;
+        constexpr ~Quaternion() noexcept = default;
+
+        constexpr T W() const noexcept;
+        constexpr T X() const noexcept;
+        constexpr T Y() const noexcept;
+        constexpr T Z() const noexcept;
+
+        /**
+         * @brief Creates a quaternion representing an identity transformation.
+         * @return Identity quaternion.
+         */
+        static constexpr Quaternion Identity() noexcept;
+
+        /**
+         * @brief Computes the dot product between quaternions.
+         * @param quat Quaternion to compute the dot product with.
+         * @return Quaternions' dot product.
+         */
+        constexpr T Dot(const Quaternion& quat) const noexcept;
+        /**
+         * @brief Computes the norm of the quaternion.
+         * @note This requires a square root, which is expensive. As such, @ref ComputeSquaredNorm should be preferred.
+         *       This function should be use only when the actual length is needed.
+         * @return Quaternion's norm.
+         */
+        constexpr T ComputeNorm() const noexcept;
+        /**
+         * @brief Computes the squared norm of the quaternion. The squared norm is equal to the addition of all
+         *        components (real & complexes) squared.
+         * @note This requires no square root. As such, it should be preferred over @ref ComputeNorm.
+         * @return Quaternion's squared norm.
+         */
+        constexpr T ComputeSquaredNorm() const noexcept;
+        /**
+         * @brief Computes the normalized quaternion to make it a unit one. A unit quaternion is also called a
+         *        [versor](https://en.wikipedia.org/wiki/Versor).
+         * @return Normalized quaternion.
+         */
+        constexpr Quaternion Normalize() const noexcept;
+        /**
+         * @brief Computes the linear interpolation between quaternions, according to a coefficient.
+         * @param quat Quaternion to be interpolated with.
+         * @param coeff Coefficient between 0 (returns the current quaternion) and 1 (returns the given quaternion).
+         * @return Linearly interpolated quaternion.
+         */
+        constexpr Quaternion Lerp(const Quaternion& quat, T coeff) const noexcept;
+        /**
+         * @brief Computes the normalized linear interpolation between quaternions, according to a coefficient.
+         * @param quat Quaternion to be interpolated with.
+         * @param coeff Coefficient between 0 (returns the normalized current quaternion) and 1 (returns the normalized
+         *              given quaternion).
+         * @return Normalized linearly interpolated quaternion.
+         */
+        constexpr Quaternion NLerp(const Quaternion& quat, T coeff) const noexcept;
+        /**
+         * @brief Computes the spherical linear interpolation between normalized quaternions, according to a coefficient.
+         * @note Both quaternions (the current & given ones) must be normalized before calling this function.
+         * @param quat Quaternion to be interpolated with. Must be normalized.
+         * @param coeff Coefficient between 0 (returns the current quaternion) and 1 (returns the given quaternion).
+         * @return Spherically interpolated quaternion.
+         */
+        constexpr Quaternion SLerp(const Quaternion& quat, T coeff) const noexcept;
+        /**
+         * @brief Computes the conjugate of the quaternion. A quaternion's conjugate is simply computed by multiplying
+         *        the complex components by -1.
+         * @return Quaternion's conjugate.
+         */
+        constexpr Quaternion Conjugate() const noexcept;
+        /**
+         * @brief Computes the inverse (or reciprocal) of the quaternion. Inverting a quaternion consists of dividing
+         *        the components of the conjugate by the squared norm.
+         * @return Quaternion's inverse.
+         */
+        constexpr Quaternion Inverse() const noexcept;
+        /**
+         * @brief Computes the rotation matrix represented by the quaternion. This operation automatically scales the
+         *        matrix so that it returns a unit one.
+         * @return Rotation matrix.
+         */
+        constexpr Mat4<T> ComputeMatrix() const noexcept;
+
+        /**
+         * @brief Default copy assignment operator.
+         * @return Reference to the copied quaternion.
+         */
+        constexpr Quaternion& operator=(const Quaternion&) noexcept = default;
+        /**
+         * @brief Default move assignment operator.
+         * @return Reference to the moved quaternion.
+         */
+        constexpr Quaternion& operator=(Quaternion&&) noexcept = default;
+        /**
+         * @brief Quaternions multiplication operator.
+         * @param quat Quaternion to be multiplied by.
+         * @return Result of the multiplied quaternions.
+         */
+        constexpr Quaternion operator*(const Quaternion& quat) const noexcept;
+        /**
+         * @brief Quaternions multiplication assignment operator.
+         * @param quat Quaternion to be multiplied by.
+         * @return Reference to the modified original quaternion.
+         */
+        constexpr Quaternion& operator*=(const Quaternion& quat) noexcept;
+        /**
+         * @brief Quaternion equality comparison operator. This uses a near-equality algorithm to take floating-point
+         *        error into account.
+         * @param quat Quaternion to be compared to.
+         * @return Whether the quaternions are nearly equal or not.
+         */
+        constexpr bool operator==(const Quaternion& quat) const noexcept;
+        /**
+         * @brief Quaternion inequality comparison operator. This uses a near-equality algorithm to take floating-point
+         *        error into account.
+         * @param quat Quaternion to be compared to.
+         * @return Whether the quaternions not equal or if they are.
+         */
+        constexpr bool operator!=(const Quaternion& quat) const noexcept;
+        /**
+         * @brief Matrix conversion operator; computes the rotation matrix represented by the quaternion.
+         * @return Rotation matrix.
+         */
+        constexpr operator Mat4<T>() const noexcept;
+        /**
+         * @brief Output stream operator.
+         * @param stream Stream to output to.
+         * @param quat Quaternion to be output.
+         * @return The modified stream.
+         */
+        friend std::ostream& operator<<<>(std::ostream& stream, const Quaternion& quat);
+
+    private:
+        constexpr Quaternion Lerp(const Quaternion& quat, T currentCoeff, T otherCoeff) const noexcept;
+
+        T m_Real{};
+        Vec3<T> m_Complexes{};
+    };
+
+    /**
+     * @brief Quaternion-vector multiplication. Rotates the vector by the rotation represented by the quaternion.
+     *        The quaternion must be normalized.
+     * @tparam T Type of the quaternion's & vector's data.
+     * @param quat Quaternion to rotate by.
+     * @param vec Vector to be rotated.
+     * @return Rotated vector.
+     */
+    template <typename T>
+    constexpr Vec3<T> operator*(const Quaternion<T>& quat, const Vec3<T>& vec) noexcept;
+
+    /**
+     * @brief Vector-quaternion multiplication. Rotates the vector by the inverse rotation represented by the quaternion.
+     *        The quaternion must be normalized.
+     * @tparam T Type of the vector's & quaternion's data.
+     * @param vec Vector to be rotated.
+     * @param quat Quaternion to rotate by.
+     * @return Rotated vector.
+     */
+    template <typename T>
+    constexpr Vec3<T> operator*(const Vec3<T>& vec, const Quaternion<T>& quat) noexcept;
+}
+
+#include <FlashlightEngine/Math/Quaternion.inl>
+
+#endif // FL_MATH_QUATERNION_HPP

--- a/Include/FlashlightEngine/Math/Quaternion.hpp
+++ b/Include/FlashlightEngine/Math/Quaternion.hpp
@@ -203,7 +203,42 @@ namespace Fl {
      */
     template <typename T>
     constexpr Vec3<T> operator*(const Vec3<T>& vec, const Quaternion<T>& quat) noexcept;
+
+    // Deduction guide
+
+    template <typename T>
+    Quaternion(Degrees<T>, ...) -> Quaternion<T>;
+
+    // Aliases
+    using Quaternionf = Quaternion<F32>;
+    using Quaterniond = Quaternion<F64>;
+
+    template <U64 Index, typename T>
+    constexpr T get(const Quaternion<T>& quat) noexcept {
+        static_assert(Index < 4);
+
+        if constexpr (Index == 0)      return quat.W();
+        else if constexpr (Index == 1) return quat.X();
+        else if constexpr (Index == 2) return quat.Y();
+        else                           return quat.Z();
+    }
 }
+
+/**
+ * @brief Specialization of std::tuple_size for Fl::Quaternion.
+ * @tparam T Type of the quaternion's data.
+ */
+template <typename T>
+struct std::tuple_size<Fl::Quaternion<T>> : std::integral_constant<std::size_t, 4> {};
+
+/**
+ * @brief Specialization of std::tuple_element for Fl::Quaternion.
+ * @tparam Index Index of the element (0, 1, 2 or 3 for the W, X, Y or Z component, respectively).
+ * @tparam T Type of the quaternion's data.
+ */
+template <std::size_t Index, typename T>
+struct std::tuple_element<Index, Fl::Quaternion<T>> { using type = T; };
+
 
 #include <FlashlightEngine/Math/Quaternion.inl>
 

--- a/Include/FlashlightEngine/Math/Quaternion.inl
+++ b/Include/FlashlightEngine/Math/Quaternion.inl
@@ -1,0 +1,270 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#include <FlashlightEngine/Core/Assert.hpp>
+#include <FlashlightEngine/Math/FloatMath.hpp>
+
+namespace Fl {
+    template <typename T>
+    constexpr Quaternion<T>::Quaternion(T w, T x, T y, T z) noexcept
+        : m_Real(w), m_Complexes(x, y, z) {
+    }
+
+    template <typename T>
+    constexpr Quaternion<T>::Quaternion(const Radians<T> angle, const Vec3<T>& axis) noexcept {
+        const T halfAngle = angle.Value / 2;
+        const T sinAngle = std::sin(halfAngle);
+
+        m_Real = std::cos(halfAngle);
+        m_Complexes = axis * sinAngle;
+    }
+
+    template <typename T>
+    constexpr Quaternion<T>::Quaternion(const Radians<T> angle, const T axisX, const T axisY, const T axisZ) noexcept
+        : Quaternion(angle, Vec3<T>(axisX, axisY, axisZ)) {
+    }
+
+    template <typename T>
+    constexpr T Quaternion<T>::W() const noexcept {
+        return m_Real;
+    }
+
+    template <typename T>
+    constexpr T Quaternion<T>::X() const noexcept {
+        return m_Complexes.X();
+    }
+
+    template <typename T>
+    constexpr T Quaternion<T>::Y() const noexcept {
+        return m_Complexes.Y();
+    }
+
+    template <typename T>
+    constexpr T Quaternion<T>::Z() const noexcept {
+        return m_Complexes.Z();
+    }
+
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::Identity() noexcept {
+        return Quaternion(1, 0, 0, 0);
+    }
+
+    template <typename T>
+    constexpr T Quaternion<T>::Dot(const Quaternion& quat) const noexcept {
+        return m_Real * quat.m_Real + m_Complexes.Dot(quat.m_Complexes);
+    }
+
+    template <typename T>
+    constexpr T Quaternion<T>::ComputeNorm() const noexcept {
+        return std::sqrt(ComputeSquaredNorm());
+    }
+
+    template <typename T>
+    constexpr T Quaternion<T>::ComputeSquaredNorm() const noexcept {
+        return Dot(*this);
+    }
+
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::Normalize() const noexcept {
+        Quaternion result = *this;
+
+        const T invNorm = 1 / ComputeNorm();
+        result.m_Real *= invNorm;
+        result.m_Complexes *= invNorm;
+
+        return result;
+    }
+
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::Lerp(const Quaternion& quat, T coeff) const noexcept {
+        FlAssert(coeff >= 0 && coeff <= 1, "The interpolation coefficient must be a number between 0 and 1.");
+
+        const T currentCoeff = 1 - coeff;
+        return Lerp(quat, currentCoeff, coeff);
+    }
+
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::NLerp(const Quaternion& quat, T coeff) const noexcept {
+        FlAssert(coeff >= 0 && coeff <= 1, "The interpolation coefficient must be a number between 0 and 1.");
+
+        const T currentCoeff = 1 - coeff;
+        // A rotation may be represented by two opposite quaternions; should the dot product between those be negative,
+        // one quaternion must be negated. This is made by negating the coefficient.
+        const T otherCoeff = Dot(quat) > 0 ? coeff : -coeff;
+
+        return Lerp(quat, currentCoeff, otherCoeff).Normalize();
+    }
+
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::SLerp(const Quaternion& quat, T coeff) const noexcept {
+        FlAssert(coeff >= 0 && coeff <= 1, "The interpolation coefficient must be a number between 0 and 1.");
+        FlAssert(FloatMath::AreNearlyEqual(ComputeSquaredNorm(), static_cast<T>(1)) &&
+                 FloatMath::AreNearlyEqual(quat.ComputeSquaredNorm(), static_cast<T>(1)),
+                 "Both quaternions must be normalized for a spherical linear interpolation to be performed.");
+
+        const T cosAngle = Dot(quat);
+
+        T currentCoeff{};
+        T otherCoeff{};
+
+        // Checking the angle between the quaternions; if the angle is sufficient, perform an actual spherical
+        // interpolation.
+        if (std::abs(cosAngle) < static_cast<T>(0.99999)) {
+            const T angle = std::acos(cosAngle);
+            const T invSinAngle = 1 / std::sin(angle);
+
+            currentCoeff = std::sin((1 - coeff) * angle) * invSinAngle;
+            otherCoeff = std::sin(coeff * angle) * invSinAngle;
+        } else {
+            // If the angle is small enough, a simple linear interpolation is performed.
+            currentCoeff = 1 - coeff;
+            otherCoeff = coeff;
+        }
+
+        // Negating one quaternion if the angle is negative.
+        otherCoeff = cosAngle > 0 ? otherCoeff : -otherCoeff;
+        return Lerp(quat, currentCoeff, otherCoeff);
+    }
+
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::Conjugate() const noexcept {
+        Quaternion result = *this;
+        result.m_Complexes = -m_Complexes;
+
+        return result;
+    }
+
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::Inverse() const noexcept {
+        Quaternion result = *this;
+        const T sqNorm = ComputeSquaredNorm();
+
+        if (sqNorm > 0) {
+            const T invSqNorm = 1 / sqNorm;
+
+            result.m_Real *= invSqNorm;
+            result.m_Complexes *= invSqNorm;
+        }
+
+        return result;
+    }
+
+    // @formatter:off
+    // clang-format off
+    template <typename T>
+    constexpr Mat4<T> Quaternion<T>::ComputeMatrix() const noexcept {
+        const T invSqNorm = 1 / ComputeSquaredNorm();
+
+        const T xx = (2 * m_Complexes.X() * m_Complexes.X()) * invSqNorm;
+        const T yy = (2 * m_Complexes.Y() * m_Complexes.Y()) * invSqNorm;
+        const T zz = (2 * m_Complexes.Z() * m_Complexes.Z()) * invSqNorm;
+
+        const T xy = (2 * m_Complexes.X() * m_Complexes.X()) * invSqNorm;
+        const T xz = (2 * m_Complexes.Y() * m_Complexes.Y()) * invSqNorm;
+        const T yz = (2 * m_Complexes.Z() * m_Complexes.Z()) * invSqNorm;
+
+        const T xw = (2 * m_Complexes.X() * m_Real) * invSqNorm;
+        const T yw = (2 * m_Complexes.Y() * m_Real) * invSqNorm;
+        const T zw = (2 * m_Complexes.Z() * m_Real) * invSqNorm;
+
+        return Mat4<T>(1 - yy - zz,       xy - zw,           xz + yw,           static_cast<T>(0),
+                       xy + zw,           1 - xx - zz,       yz - xw,           static_cast<T>(0),
+                       xz - yw,           yz + xw,           1 - xx - yy,       static_cast<T>(0),
+                       static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1));
+    }
+    // @formatter:on
+    // clang-format on
+
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::operator*(const Quaternion& quat) const noexcept {
+        Quaternion result = *this;
+        result *= quat;
+
+        return result;
+    }
+
+    // @formatter:off
+    // clang-format off
+    template <typename T>
+    constexpr Quaternion<T>& Quaternion<T>::operator*=(const Quaternion& quat) noexcept {
+        const Quaternion copy = *this;
+
+        m_Real = copy.m_Real          * quat.m_Real
+               - copy.m_Complexes.X() * quat.m_Complexes.X()
+               - copy.m_Complexes.Y() * quat.m_Complexes.Y()
+               - copy.m_Complexes.Z() * quat.m_Complexes.Z();
+
+        m_Complexes.X() = copy.m_Real          * quat.m_Complexes.X()
+                        - copy.m_Complexes.X() * quat.m_Real
+                        - copy.m_Complexes.Y() * quat.m_Complexes.Z()
+                        - copy.m_Complexes.Z() * quat.m_Complexes.Y();
+
+        m_Complexes.Y() = copy.m_Real          * quat.m_Complexes.Y()
+                        - copy.m_Complexes.X() * quat.m_Complexes.Z()
+                        + copy.m_Complexes.Y() * quat.m_Real
+                        + copy.m_Complexes.Z() * quat.m_Complexes.X();
+
+        m_Complexes.Z() = copy.m_Real          * quat.m_Complexes.Z()
+                        + copy.m_Complexes.X() * quat.m_Complexes.Y()
+                        - copy.m_Complexes.Y() * quat.m_Complexes.X()
+                        + copy.m_Complexes.Z() * quat.m_Real;
+
+        return *this;
+    }
+    // @formatter:on
+    // clang-format on
+
+    template <typename T>
+    constexpr bool Quaternion<T>::operator==(const Quaternion& quat) const noexcept {
+        return FloatMath::AreNearlyEqual(*this, quat);
+    }
+
+    template <typename T>
+    constexpr bool Quaternion<T>::operator!=(const Quaternion& quat) const noexcept {
+        return !(*this == quat);
+    }
+
+    template <typename T>
+    constexpr Quaternion<T>::operator Mat4<T>() const noexcept {
+        return ComputeMatrix();
+    }
+
+    template <typename T>
+    std::ostream& operator<<(std::ostream& stream, const Quaternion<T>& quat) {
+        stream << "[ " << quat.W() << ", " << quat.X() << ", " << quat.Y() << ", " << quat.Z() << " ]";
+        return stream;
+    }
+
+    // @formatter:off
+    // clang-format off
+    template <typename T>
+    constexpr Quaternion<T> Quaternion<T>::Lerp(const Quaternion& quat, T currentCoeff, T otherCoeff) const noexcept {
+        return Quaternion(m_Real          * currentCoeff + quat.m_Real          * otherCoeff,
+                          m_Complexes.X() * currentCoeff + quat.m_Complexes.X() * otherCoeff,
+                          m_Complexes.Y() * currentCoeff + quat.m_Complexes.Y() * otherCoeff,
+                          m_Complexes.Z() * currentCoeff + quat.m_Complexes.Z() * otherCoeff);
+    }
+    // @formatter:on
+    // clang-format on
+
+    template <typename T>
+    constexpr Vec3<T> operator*(const Quaternion<T>& quat, const Vec3<T>& vec) noexcept {
+        // Adapted from https://fgiesen.wordpress.com/2019/02/09/rotating-a-single-vector-using-a-quaternion/
+
+        const Vec3<T> quatVec(quat.X(), quat.Y(), quat.Z());
+        const Vec3<T> doubleQuatVecCross = static_cast<T>(2) * quatVec.Cross(vec);
+        return vec + quat.W() * doubleQuatVecCross + quatVec.Cross(doubleQuatVecCross);
+    }
+
+    template <typename T>
+    constexpr Vec3<T> operator*(const Vec3<T>& vec, const Quaternion<T>& quat) noexcept {
+        // Adapted from https://fgiesen.wordpress.com/2019/02/09/rotating-a-single-vector-using-a-quaternion/
+
+        const Vec3<T> quatVec(quat.X(), quat.Y(), quat.Z());
+        const Vec3<T> doubleQuatVecCross = static_cast<T>(2) * vec.Cross(quatVec);
+        return vec + quat.W() * doubleQuatVecCross + doubleQuatVecCross.Cross(quatVec);
+    }
+}

--- a/Include/FlashlightEngine/Math/Quaternion.inl
+++ b/Include/FlashlightEngine/Math/Quaternion.inl
@@ -156,24 +156,24 @@ namespace Fl {
     // clang-format off
     template <typename T>
     constexpr Mat4<T> Quaternion<T>::ComputeMatrix() const noexcept {
-        const T invSqNorm = 1 / ComputeSquaredNorm();
+		const T invSqNorm = 1 / ComputeSquaredNorm();
 
-        const T xx = (2 * m_Complexes.X() * m_Complexes.X()) * invSqNorm;
+		const T xx = (2 * m_Complexes.X() * m_Complexes.X()) * invSqNorm;
         const T yy = (2 * m_Complexes.Y() * m_Complexes.Y()) * invSqNorm;
         const T zz = (2 * m_Complexes.Z() * m_Complexes.Z()) * invSqNorm;
 
-        const T xy = (2 * m_Complexes.X() * m_Complexes.X()) * invSqNorm;
-        const T xz = (2 * m_Complexes.Y() * m_Complexes.Y()) * invSqNorm;
-        const T yz = (2 * m_Complexes.Z() * m_Complexes.Z()) * invSqNorm;
+		const T xy = (2 * m_Complexes.X() * m_Complexes.Y()) * invSqNorm;
+		const T xz = (2 * m_Complexes.X() * m_Complexes.Z()) * invSqNorm;
+		const T yz = (2 * m_Complexes.Y() * m_Complexes.Z()) * invSqNorm;
 
-        const T xw = (2 * m_Complexes.X() * m_Real) * invSqNorm;
-        const T yw = (2 * m_Complexes.Y() * m_Real) * invSqNorm;
-        const T zw = (2 * m_Complexes.Z() * m_Real) * invSqNorm;
+		const T xw = (2 * m_Complexes.X() * m_Real) * invSqNorm;
+		const T yw = (2 * m_Complexes.Y() * m_Real) * invSqNorm;
+		const T zw = (2 * m_Complexes.Z() * m_Real) * invSqNorm;
 
-        return Mat4<T>(1 - yy - zz,       xy - zw,           xz + yw,           static_cast<T>(0),
-                       xy + zw,           1 - xx - zz,       yz - xw,           static_cast<T>(0),
-                       xz - yw,           yz + xw,           1 - xx - yy,       static_cast<T>(0),
-                       static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1));
+		return Mat4<T>(1 - yy - zz,       xy - zw,           xz + yw,           static_cast<T>(0),
+			           xy + zw,           1 - xx - zz,       yz - xw,           static_cast<T>(0),
+			           xz - yw,           yz + xw,  1 -      xx - yy,           static_cast<T>(0),
+			           static_cast<T>(0), static_cast<T>(0), static_cast<T>(0), static_cast<T>(1));
     }
     // @formatter:on
     // clang-format on
@@ -190,29 +190,29 @@ namespace Fl {
     // clang-format off
     template <typename T>
     constexpr Quaternion<T>& Quaternion<T>::operator*=(const Quaternion& quat) noexcept {
-        const Quaternion copy = *this;
+		const Quaternion copy = *this;
 
-        m_Real = copy.m_Real          * quat.m_Real
-               - copy.m_Complexes.X() * quat.m_Complexes.X()
+		m_Real = copy.m_Real          * quat.m_Real
+			   - copy.m_Complexes.X() * quat.m_Complexes.X()
                - copy.m_Complexes.Y() * quat.m_Complexes.Y()
                - copy.m_Complexes.Z() * quat.m_Complexes.Z();
 
-        m_Complexes.X() = copy.m_Real          * quat.m_Complexes.X()
-                        - copy.m_Complexes.X() * quat.m_Real
-                        - copy.m_Complexes.Y() * quat.m_Complexes.Z()
+		m_Complexes.X() = copy.m_Real          * quat.m_Complexes.X()
+			            + copy.m_Complexes.X() * quat.m_Real
+                        + copy.m_Complexes.Y() * quat.m_Complexes.Z()
                         - copy.m_Complexes.Z() * quat.m_Complexes.Y();
 
-        m_Complexes.Y() = copy.m_Real          * quat.m_Complexes.Y()
-                        - copy.m_Complexes.X() * quat.m_Complexes.Z()
-                        + copy.m_Complexes.Y() * quat.m_Real
-                        + copy.m_Complexes.Z() * quat.m_Complexes.X();
+		m_Complexes.Y() = copy.m_Real          * quat.m_Complexes.Y()
+			            - copy.m_Complexes.X() * quat.m_Complexes.Z()
+			            + copy.m_Complexes.Y() * quat.m_Real
+			            + copy.m_Complexes.Z() * quat.m_Complexes.X();
 
-        m_Complexes.Z() = copy.m_Real          * quat.m_Complexes.Z()
-                        + copy.m_Complexes.X() * quat.m_Complexes.Y()
+		m_Complexes.Z() = copy.m_Real * quat.m_Complexes.Z()
+			            + copy.m_Complexes.X() * quat.m_Complexes.Y()
                         - copy.m_Complexes.Y() * quat.m_Complexes.X()
                         + copy.m_Complexes.Z() * quat.m_Real;
 
-        return *this;
+		return *this;
     }
     // @formatter:on
     // clang-format on

--- a/Include/FlashlightEngine/Math/Transform.hpp
+++ b/Include/FlashlightEngine/Math/Transform.hpp
@@ -1,0 +1,138 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_MATH_TRANSFORM_HPP
+#define FL_MATH_TRANSFORM_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+#include <FlashlightEngine/Core/Component.hpp>
+#include <FlashlightEngine/Math/Quaternion.hpp>
+#include <FlashlightEngine/Math/Vector.hpp>
+
+namespace Fl {
+    template <typename T, U64 Width, U64 Height>
+    class Matrix;
+    using Mat4f = Matrix<F32, 4, 4>;
+
+    template <typename T>
+    struct Radians;
+    using Radiansf = Radians<F32>;
+
+    /**
+     * @brief Transform entity component which handles transformations in a 3D space
+     */
+    class Transform : public Component {
+    public:
+        inline explicit Transform(const Vec3f& position = Vec3f(0.f), const Quaternionf& rotation = Quaternionf::Identity(), const Vec3f& scale = Vec3f(1.f));
+
+        inline const Vec3f& GetPosition() const;
+        inline const Quaternionf& GetRotation() const;
+        inline const Vec3f& GetScale() const;
+        inline bool WasUpdated() const;
+
+        void SetPosition(const Vec3f& position);
+        inline void SetPosition(F32 x, F32 y, F32 z);
+        void SetRotation(const Quaternionf& rotation);
+        void SetRotation(Radiansf angle, const Vec3f& axis);
+        void SetScale(const Vec3f& scale);
+        inline void SetScale(F32 x, F32 y, F32 z);
+        inline void SetScale(F32 coeff);
+        inline void SetUpdated(bool status);
+
+        /**
+         * @brief Moves by the given values in relative coordinates (takes rotation into account).
+         * @param displacement Displacement to be moved by.
+         */
+        inline void Move(const Vec3f& displacement);
+        /**
+         * @brief Moves by the given values in relative coordinates (takes rotation into account).
+		 * @param x Value to be moved by on the X axis.
+		 * @param y Value to be moved by on the Y axis.
+         * @param Z Value to be moved by on the Z axis.
+         */
+        inline void Move(F32 x, F32 y, F32 z);
+        /**
+         * @brief Translates by the given values in absolute coordinates (does not take rotation into account).
+         * @param displacement Displacement to be translated by.
+         */
+        inline void Translate(const Vec3f& displacement);
+        /**
+         * @brief Translates by the given values in absolute coordinates (does not take rotation into account).
+		 * @param x Value to be translated by on the X axis.
+		 * @param y Value to be translated by on the Y axis.
+		 * @param Z Value to be translated by on the Z axis.
+		 */
+        void Translate(F32 x, F32 y, F32 z);
+        /**
+         * @brief Rotates by the given quaternion.
+         * @param rotation Rotation quaternion to rotate by.
+         */
+        void Rotate(const Quaternionf& rotation);
+        /**
+         * @brief Rotates by the given angle around the given axis.
+         * @note The axis must be a normalized vector for this function to work properly.
+         * @param angle Angle to rotate by.
+         * @param axis Axis to rotate around.
+         */
+        void Rotate(Radiansf angle, const Vec3f& axis);
+        /**
+         * @brief Rotates around the given axes. This locks the up vector, preventing any rolling effect.
+         * @param xAngle Value of X to rotate around.
+         * @param yAngle Value of Y to rotate around.
+         */
+		void Rotate(Radiansf xAngle, Radiansf yAngle);
+        /**
+         * @brief Rotates around the given axes.
+         * @param xAngle Value of X to rotate around.
+         * @param yAngle Value of Y to rotate around.
+         * @param zAngle Value of Z to rotate around.
+         */
+		void Rotate(Radiansf xAngle, Radiansf yAngle, Radiansf zAngle);
+        /**
+         * @brief Scales by the given values.
+         *        The scaling is a coefficient: scaling by a value of 2 doubles the size, while a value of 0.5 shrinks it by half.
+         * @param values Values to be scaled by.
+         */
+        inline void Scale(const Vec3f& values);
+        /**
+         * @brief Scales by the given values.
+         *        The scaling is a coefficient: scaling by a value of 2 doubles the size, while a value of 0.5 shrinks it by half.
+		 * @param x Value to be scaled by on the X axis.
+		 * @param y Value to be scaled by on the Y axis.
+		 * @param z Value to be scaled by on the Z axis.
+         */
+        void Scale(F32 x, F32 y, F32 z);
+        /**
+         * @brief Scales by the given value on all 3 axes.
+         *        The scaling is a coefficient: scaling by a value of 2 doubles the size, while a value of 0.5 shrinks it by half.
+         * @param coeff Coefficient to be scaled by on all axes.
+         */
+        inline void Scale(F32 coeff);
+        /**
+         * @brief Computes the translation matrix (identity matrix with the translation in the last column).
+         * @param reverseTranslation Whether the translation should be reversed (negated) or not.
+         * @return Translation matrix.
+         */
+        Mat4f ComputeTranslationMatrix(bool reverseTranslation = false) const;
+        /**
+         * @brief Computes the transformation matrix.
+         *        This matrix combines all three features: translation, rotation & scale.
+         * @return Transformation matrix.
+         */
+        Mat4f ComputeTransformMatrix() const;
+
+    private:
+        Vec3f m_Position{};
+        Quaternionf m_Rotation = Quaternionf::Identity();
+        Vec3f m_Scale{};
+        bool m_Updated{true};
+    };
+}
+
+#include <FlashlightEngine/Math/Transform.inl>
+
+#endif // FL_MATH_TRANSFORM_HPP

--- a/Include/FlashlightEngine/Math/Transform.inl
+++ b/Include/FlashlightEngine/Math/Transform.inl
@@ -5,7 +5,7 @@
 #pragma once
 
 namespace Fl {
-    inline explicit Transform::Transform(const Vec3f& position, const Quaternionf& rotation, const Vec3f& scale)
+    inline Transform::Transform(const Vec3f& position, const Quaternionf& rotation, const Vec3f& scale)
         : m_Position{ position }, m_Rotation{ rotation }, m_Scale{ scale } {
 	}
 

--- a/Include/FlashlightEngine/Math/Transform.inl
+++ b/Include/FlashlightEngine/Math/Transform.inl
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+namespace Fl {
+    inline explicit Transform::Transform(const Vec3f& position, const Quaternionf& rotation, const Vec3f& scale)
+        : m_Position{ position }, m_Rotation{ rotation }, m_Scale{ scale } {
+	}
+
+	inline const Vec3f& Transform::GetPosition() const {
+		return m_Position;
+	}
+
+	inline const Quaternionf& Transform::GetRotation() const {
+		return m_Rotation;
+	}
+
+	inline const Vec3f& Transform::GetScale() const {
+		return m_Scale;
+	}
+
+	inline bool Transform::WasUpdated() const {
+		return m_Updated;
+	}
+
+	inline void Transform::SetPosition(const F32 x, const F32 y, const F32 z) {
+		SetPosition(Vec3f(x, y, z));
+	}
+
+	inline void Transform::SetScale(const F32 x, const F32 y, const F32 z) {
+		SetScale(Vec3f(x, y, z));
+	}
+
+	inline void Transform::SetScale(const F32 coeff) {
+		SetScale(Vec3f(coeff));
+	}
+
+	inline void Transform::SetUpdated(const bool status) {
+		m_Updated = status;
+	}
+
+	inline void Transform::Move(const Vec3f& displacement) {
+		Translate(m_Rotation * displacement);
+	}
+
+	inline void Transform::Move(const F32 x, const F32 y, const F32 z) {
+		Move(Vec3f(x, y, z));
+	}
+
+	inline void Transform::Translate(const Vec3f& displacement) {
+		Translate(displacement.X(), displacement.Y(), displacement.Z());
+	}
+
+	inline void Transform::Scale(const Vec3f& values) {
+		Scale(values.X(), values.Y(), values.Z());
+	}
+
+	inline void Transform::Scale(const F32 coeff) {
+		Scale(coeff, coeff, coeff);
+	}
+}

--- a/Include/FlashlightEngine/Math/Utils.hpp
+++ b/Include/FlashlightEngine/Math/Utils.hpp
@@ -1,0 +1,152 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_MATH_UTILS_HPP
+#define FL_MATH_UTILS_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+#include <FlashlightEngine/Core/Assert.hpp>
+#include <FlashlightEngine/Math/Constants.hpp>
+#include <FlashlightEngine/Math/Vector.hpp>
+
+#include <algorithm>
+#include <type_traits>
+#include <vector>
+
+namespace Fl::MathUtils {
+	/**
+	 * @brief Computes the linear interpolation between two values, according to a coefficient.
+	 * @tparam T Type of the values to compute the interpolation with.
+	 * @tparam CoefficientType Type of the coefficient to apply.
+	 * @param min Minimum value (lower bound).
+	 * @param max Maximum value (upper bound).
+	 * @param coeff Coefficient between 0 (returns `min`) and 1 (returns `max`).
+	 * @return Computed linear interpolation between `min` and `max`.
+	 */
+	template <typename T, typename CoefficientType>
+	constexpr T Lerp(T min, T max, CoefficientType coeff);
+
+	/**
+	 * @brief Computes the component-wise linear interpolation between two vectors, according to a coefficient.
+	 * @tparam T Type of the vectors' data to compute the interpolation with.
+	 * @tparam Size Size of the vectors to interpolate.
+	 * @tparam CoefficientType Type of the coefficient to apply.
+	 * @param min Minimum value (lower bound).
+	 * @param max Maximum value (upper bound).
+	 * @param coeff Coefficient between 0 (returns `min`) and 1 (returns `max`).
+	 * @return Computed linear interpolation between `min` and `max`.
+	 */
+	template <typename T, U64 Size, typename CoefficientType>
+	constexpr Vector<T, Size> Lerp(const Vector<T, Size>& min, const Vector<T, Size>& max, CoefficientType coeff);
+
+	/**
+	 * @brief Computes the cubic [Hermite interpolation](https://en.wikipedia.org/wiki/Hermite_interpolation) of a value.
+	 *
+	 *       1.0    |               |___
+	 *              |           .-~"|
+	 *              |         ,^    |
+	 *              |        /      |
+	 *              |       /       |
+	 *              |      /        |
+	 *              |    ,v         |
+	 *       0.0 ___|,.-"           |
+	 *              ^               ^
+	 *             0.0             1.0
+	 *
+	 * @tparam T Type to compute the interpolation with.
+	 * @param value Value to be interpolated (must be between 0 & 1).
+	 * @return The interpolated value (between 0 & 1).
+	 */
+	template <typename T>
+	constexpr T Smoothstep(T value) noexcept;
+
+	/**
+	 * @brief Computes the cubic [Hermite interpolation](https://en.wikipedia.org/wiki/Hermite_interpolation) between two thresholds.
+	 *
+	 * Any value below `minThresh` will return 0, and any above `maxThresh` will return 1. Between both thresholds, a smooth interpolation is performed.
+	 *
+	 *       1.0    |               |___
+	 *              |           .-~"|
+	 *              |         ,^    |
+	 *              |        /      |
+	 *              |       /       |
+	 *              |      /        |
+	 *              |    ,v         |
+	 *       0.0 ___|,.-"           |
+	 *              ^               ^
+	 *          minThresh       maxThresh
+	 *
+	 * This is equivalent to [GLSL's smoothstep function](http://docs.gl/sl4/smoothstep).
+	 * @tparam T Type to compute the interpolation with.
+	 * @param minThresh Minimum threshold value.
+	 * @param maxThresh Maximum threshold value.
+	 * @param value Value to be interpolated.
+	 * @return 0 if `value` is lower than `minThresh`.
+	 * @return 1 if `value` is greater than `maxThresh`.
+	 * @return The interpolated value (between 0 & 1) otherwise.
+	 */
+	template <typename T>
+	constexpr T Smoothstep(T minThresh, T maxThresh, T value) noexcept;
+
+	/**
+	 * @brief Computes a quintic interpolation of a value.
+	 *
+	 * This is Ken Perlin's [smoothstep variation](https://en.wikipedia.org/wiki/Smoothstep#Variations), which produces a slightly smoother smoothstep.
+	 * @tparam T Type to compute the interpolation with.
+	 * @param value Value to be interpolated (must be between 0 & 1).
+	 * @return The interpolated value (between 0 & 1).
+	 */
+	template <typename T>
+	constexpr T Smootherstep(T value) noexcept;
+
+	/**
+	 * @brief Computes a quintic interpolation between two thresholds.
+     *
+     * This is Ken Perlin's [smoothstep variation](https://en.wikipedia.org/wiki/Smoothstep#Variations), which produces a slightly smoother smoothstep.
+     * @tparam T Type to compute the interpolation with.
+     * @param minThresh Minimum threshold value.
+     * @param maxThresh Maximum threshold value.
+     * @param value Value to be interpolated.
+     * @return 0 if `value` is lower than `minThresh`.
+     * @return 1 if `value` is greater than `maxThresh`.
+     * @return The interpolated value (between 0 & 1) otherwise.
+	 */
+	template <typename T>
+	constexpr T Smootherstep(T minThresh, T maxThresh, T value) noexcept;
+
+	/**
+	 * @brief Computes an [orthonormal basis from a single vector](https://graphics.pixar.com/library/OrthonormalB/), according to the right hand rule.
+	 *
+	 * Note that the example diagram below represents one possible solution; the vectors may not necessarily be in these directions relatively to the input.
+	 *
+	 *           axis3
+	 *            ^
+	 *            |
+	 *            +---> axis2
+	 *           /
+	 *          v
+	 *       input
+	 *
+	 * @tparam T Type of the basis' vectors.
+	 * @param input Base vector from which to compute the basis. Must be normalized.
+	 * @param axis2 Second vector of the computed basis.
+	 * @param axis3 Third vector of the computed basis.
+	 */
+	template <typename T>
+	void ComputeOrthonormalBasis(const Vec3<T>& input, Vec3<T>& axis2, Vec3<T>& axis3);
+
+	/**
+	 * @brief Computes points on the Fibonacci sphere, giving evenly distributed points around a unit sphere.
+	 * @param pointCount Number of points to compute.
+	 * @return Points on the Fibonacci sphere. All vectors are of length 1.
+	 */
+	inline std::vector<Vec3f> ComputeFibonacciSpherePoints(U64 pointCount);
+}
+
+#include <FlashlightEngine/Math/Utils.inl>
+
+#endif // FL_MATH_UTILS_HPP

--- a/Include/FlashlightEngine/Math/Utils.inl
+++ b/Include/FlashlightEngine/Math/Utils.inl
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+namespace Fl::MathUtils {
+	template <typename T, typename CoefficientType>
+	constexpr T Lerp(T min, T max, CoefficientType coeff) {
+		static_assert(std::is_floating_point_v<CoefficientType>, "[Error] The coefficient must be a floating point value.");
+
+		return static_cast<T>(static_cast<CoefficientType>(min) * (1 - coeff) + static_cast<CoefficientType>(max) * coeff);
+	}
+
+	template <typename T, U64 Size, typename CoefficientType>
+	constexpr Vector<T, Size> Lerp(const Vector<T, Size>& min, const Vector<T, Size>& max, CoefficientType coeff) {
+		static_assert(std::is_floating_point_v<CoefficientType>, "[Error] The coefficient must be a floating point value.");
+
+		Vector<T, Size> result{};
+
+		for (U64 i = 0; i < Size; i++) {
+			result[i] = Lerp(min[i], max[i], coeff);
+		}
+
+		return result;
+	}
+
+	template <typename T>
+	constexpr T Smoothstep(T value) noexcept {
+		static_assert(std::is_floating_point_v<T>, "[Error] The interpolation type must be floating point.");
+		FlAssert(value >= 0 && value <= 1, "The value must be between 0 and 1");
+
+		return value * value * (3 - 2 * value);
+	}
+
+	template <typename T>
+	constexpr T Smoothstep(T minThresh, T maxThresh, T value) noexcept {
+		static_assert(std::is_floating_point_v<T>, "[Error] The interpolation type must be floating point.");
+		FlAssert(maxThresh > minThresh, "The smoothstep's maximum threshold must be greater than the minimum one.");
+
+		const T clampedVal = std::clamp((value - minThresh) / (maxThresh - minThresh), static_cast<T>(0), static_cast<T>(1));
+		return Smoothstep(clampedVal);
+	}
+
+	template <typename T>
+	constexpr T Smootherstep(T value) noexcept {
+		static_assert(std::is_floating_point_v<T>, "[Error] The interpolation type must be floating point.");
+		FlAssert(value >= 0 && value <= 1, "The value must be between 0 and 1.");
+
+		return value * value * value * (value * (value * 6 - 15) + 10);
+	}
+
+	template <typename T>
+	constexpr T Smootherstep(T minThresh, T maxThresh, T value) noexcept {
+		static_assert(std::is_floating_point_v<T>, "[Error] The interpolation type must be floating point.");
+		FlAssert(maxThresh > minThresh, "The smootherstep's maximum threshold must be greater than the minimum one.");
+
+		const T clampedVal = std::clamp((value - minThresh) / (maxThresh - minThresh), static_cast<T>(0), static_cast<T>(1));
+		return Smootherstep(clampedVal);
+	}
+
+	template <typename T>
+	void ComputeOrthonormalBasis(const Vec3<T>& input, Vec3<T>& axis2, Vec3<T>& axis3) {
+		static_assert(std::is_floating_point_v<T>, "[Error] Vectors must be of a floating-point type to compute an orthonormal basis from.");
+
+		const T sign = std::copysign(static_cast<T>(1), input.Z());
+		const T a    = static_cast<T>(-1) / (sign + input.Z());
+		const T b    = input.X() * input.Y() * a;
+
+		axis2 = Vec3<T>(static_cast<T>(1) + sign * input.X() * input.X() * a, sign * b, -sign * input.X());
+		axis3 = Vec3<T>(b, sign + input.Y() * input.Y() * a, -input.Y());
+	}
+
+	inline std::vector<Vec3f> ComputeFibonacciSpherePoints(U64 pointCount) {
+		std::vector<Vec3f> fiboPoints(pointCount);
+
+		for (U64 i = 0; i < pointCount; i++) {
+			const F32 theta  = 2.f * Constants::Pi<F32> *static_cast<F32>(i) / Constants::GoldenRatio<F32>;
+			const F32 cosPhi = 1.f - 2.f * (static_cast<F32>(i) + 0.5f) / static_cast<F32>(pointCount);
+			const F32 sinPhi = std::sqrt(1.f - cosPhi * cosPhi);
+
+			fiboPoints[i] = Vec3f(std::cos(theta) * sinPhi, cosPhi, std::sin(theta) * sinPhi);
+		}
+		
+		return fiboPoints;
+	}
+}

--- a/Include/FlashlightEngine/Math/Vector.hpp
+++ b/Include/FlashlightEngine/Math/Vector.hpp
@@ -29,19 +29,13 @@ namespace Fl {
     class Vector {
     public:
         constexpr Vector() noexcept = default;
-
         constexpr explicit Vector(const Vector<T, Size + 1>& vec) noexcept;
-
-        constexpr explicit Vector(const Vector<T, Size - 1>& vec, T val) noexcept;
-
+        constexpr Vector(const Vector<T, Size - 1>& vec, T val) noexcept;
         constexpr explicit Vector(T val) noexcept;
-
         template <typename... Args,
-                  // There can't be more or less values than Size
-                  typename = std::enable_if_t<sizeof...(Args) == Size>,
-                  // Given values must be of a convertible type
-                  typename = std::enable_if_t<(std::is_convertible_v<std::decay_t<Args>, T> && ...)>>
-        constexpr explicit Vector(Args&&... args) noexcept;
+                  typename = std::enable_if_t<sizeof...(Args) == Size>, // There can't be more or less values than Size
+                  typename = std::enable_if_t<(std::is_convertible_v<std::decay_t<Args>, T> && ...)>> // Given values must be of a convertible type
+        constexpr explicit Vector(Args&&... args) noexcept : m_Data{ static_cast<T>(args)... } {};
 
         constexpr ~Vector() noexcept = default;
 
@@ -147,7 +141,7 @@ namespace Fl {
          *                    integer type to avoid overflows.
          * @return The length of the vector.
          */
-        template <typename LengthType = std::conditional_t<std::is_integral_v<T>, U64, T>>
+        template <typename LengthType = std::conditional_t<std::is_integral_v<T>, F32, T>>
         constexpr LengthType ComputeLength() const noexcept;
 
         /**
@@ -281,56 +275,56 @@ namespace Fl {
          * @param vec Vector to be added.
          * @return Reference to the result of the summed vectors.
          */
-        constexpr Vector& operator+=(const Vector& vec) const noexcept;
+        constexpr Vector& operator+=(const Vector& vec) noexcept;
 
         /**
          * Element-wise vector-value addition assignment operator.
          * @param val Value to be added.
          * @return Reference to the result of the vector summed with the value.
          */
-        constexpr Vector& operator+=(T val) const noexcept;
+        constexpr Vector& operator+=(T val) noexcept;
 
         /**
          * @brief Element-wise vector-vector subtraction assignment operator.
          * @param vec Vector to be subtracted.
          * @return Reference to the result of the subtraction.
          */
-        constexpr Vector& operator-=(const Vector& vec) const noexcept;
+        constexpr Vector& operator-=(const Vector& vec) noexcept;
 
         /**
          * @brief Element-wise vector-value subtraction assignment operator.
          * @param val Value to be subtracted.
          * @return Reference to the result of the subtraction.
          */
-        constexpr Vector& operator-=(T val) const noexcept;
+        constexpr Vector& operator-=(T val) noexcept;
 
         /**
          * @brief Element-wise vector-vector multiplication assignment operator (performs a [Hadamard product](https://en.wikipedia.org/wiki/Hadamard_product_(matrices)).
          * @param vec Vector to be multiplied by.
          * @return Reference to the result of the multiplication.
          */
-        constexpr Vector& operator*=(const Vector& vec) const noexcept;
+        constexpr Vector& operator*=(const Vector& vec) noexcept;
 
         /**
          * @brief Element-wise vector-value multiplication assignment operator.
          * @param val Value to be multiplied by.
          * @return Reference to the result of the multiplication.
          */
-        constexpr Vector& operator*=(T val) const noexcept;
+        constexpr Vector& operator*=(T val) noexcept;
 
         /**
          * @brief Element-wise vector-vector division assignment operator.
          * @param vec Vector to be divided by.
          * @return Reference to the result of the division.
          */
-        constexpr Vector& operator/=(const Vector& vec) const noexcept;
+        constexpr Vector& operator/=(const Vector& vec) noexcept;
 
         /**
          * @brief Element-wise vector-value division assignment operator.
          * @param val Value to be divided by.
          * @return Reference to the result of the division.
          */
-        constexpr Vector& operator/=(T val) const noexcept;
+        constexpr Vector& operator/=(T val) noexcept;
 
         /**
          * @brief Element indexing operator.
@@ -376,7 +370,7 @@ namespace Fl {
          * @param vec Vector to output.
          * @return The modified stream.
          */
-        friend std::ostream& operator<<<>(std::ostream& stream, const Vector& vec);
+        friend std::ostream& operator<< <>(std::ostream& stream, const Vector& vec);
 
     private:
         std::array<T, Size> m_Data{};
@@ -407,17 +401,12 @@ namespace Fl {
     // Deduction guides
 
     template <typename T, typename... Args>
-    Vector(T, Args... args) -> Vector<T, sizeof...(Args) + 1>;
+    Vector(T, Args... args) -> Vector<T, sizeof...(args) + 1>;
 
     // Aliases
-    template <typename T>
-    using Vec2 = Vector<T, 2>;
-
-    template <typename T>
-    using Vec3 = Vector<T, 3>;
-
-    template <typename T>
-    using Vec4 = Vector<T, 4>;
+    template <typename T> using Vec2 = Vector<T, 2>;
+    template <typename T> using Vec3 = Vector<T, 3>;
+    template <typename T> using Vec4 = Vector<T, 4>;
 
     using Vec2b = Vec2<U8>;
     using Vec3b = Vec3<U8>;
@@ -440,10 +429,12 @@ namespace Fl {
     using Vec4d = Vec4<F64>;
 
     namespace Axis {
-        constexpr Vec3f X(1.0f, 0.0f, 0.0f);
-        constexpr Vec3f Y(0.0f, 1.0f, 0.0f);
-        constexpr Vec3f Z(0.0f, 0.0f, 1.0f);
+        constexpr Vec3f X(1.f, 0.f, 0.f);
+        constexpr Vec3f Y(0.f, 1.f, 0.f);
+        constexpr Vec3f Z(0.f, 0.f, 1.f);
     }
+
+    // These are not capitalized at the beginning because C++ requires them to be called `get` for structure bindings.
 
     /**
      * @brief Vector element fetching function for a constant lvalue reference.
@@ -454,7 +445,7 @@ namespace Fl {
      * @return Constant lvalue reference on the vector's element.
      */
     template <U64 I, typename T, U64 Size>
-    constexpr const T& Get(const Vector<T, Size>& vec);
+    constexpr const T& get(const Vector<T, Size>& vec);
 
     /**
      * @brief Vector element fetching function for a non-constant lvalue reference.
@@ -465,7 +456,7 @@ namespace Fl {
      * @return Non-constant lvalue reference on the vector's element.
      */
     template <U64 I, typename T, U64 Size>
-    constexpr T& Get(const Vector<T, Size>& vec);
+    constexpr T& get(Vector<T, Size>& vec);
 
     /**
      * @brief Vector element fetching function for a non-constant rvalue reference.
@@ -476,7 +467,7 @@ namespace Fl {
      * @return Non-constant rvalue reference on the vector's element.
      */
     template <U64 I, typename T, U64 Size>
-    constexpr T&& Get(const Vector<T, Size>& vec);
+    constexpr T&& get(Vector<T, Size>&& vec);
 }
 
 /**

--- a/Include/FlashlightEngine/Math/Vector.hpp
+++ b/Include/FlashlightEngine/Math/Vector.hpp
@@ -1,0 +1,550 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_MATH_VECTOR_HPP
+#define FL_MATH_VECTOR_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+#include <array>
+#include <cmath>
+#include <ostream>
+
+namespace Fl {
+    template <typename T, U64 Size>
+    class Vector;
+
+    template <typename T, U64 Size>
+    std::ostream& operator<<(std::ostream& stream, const Vector<T, Size>& vec);
+
+    /**
+     * @brief Vector class representing a mathematical vector with `Size` elements.
+     * @tparam T Type of the vector's members.
+     * @tparam Size Vector's size.
+     */
+    template <typename T, U64 Size>
+    class Vector {
+    public:
+        constexpr Vector() noexcept = default;
+
+        constexpr explicit Vector(const Vector<T, Size + 1>& vec) noexcept;
+
+        constexpr explicit Vector(const Vector<T, Size - 1>& vec, T val) noexcept;
+
+        constexpr explicit Vector(T val) noexcept;
+
+        template <typename... Args,
+                  // There can't be more or less values than Size
+                  typename = std::enable_if_t<sizeof...(Args) == Size>,
+                  // Given values must be of a convertible type
+                  typename = std::enable_if_t<(std::is_convertible_v<std::decay_t<Args>, T> && ...)>>
+        constexpr explicit Vector(Args&&... args) noexcept;
+
+        constexpr ~Vector() noexcept = default;
+
+        Vector(const Vector&) noexcept = default;
+        Vector(Vector&&) noexcept = default;
+
+        [[nodiscard]] constexpr U64 GetSize() const noexcept;
+        [[nodiscard]] constexpr const std::array<T, Size>& GetData() const noexcept;
+        [[nodiscard]] constexpr std::array<T, Size>& GetData() noexcept;
+        [[nodiscard]] constexpr const T* GetDataPtr() const noexcept;
+        [[nodiscard]] constexpr T* GetDataPtr() noexcept;
+
+        /**
+         * @brief Gets the vector's X component.
+         * @return Constant reference to the vector's X component.
+         */
+        constexpr const T& X() const noexcept;
+
+        /**
+         * @brief Gets the vector's X component.
+         * @return Reference to the vector's X component.
+         */
+        constexpr T& X() noexcept;
+
+        /**
+         * @brief Gets the vector's X component.
+         * @return Constant reference to the vector's X component.
+         */
+        constexpr const T& Y() const noexcept;
+
+        /**
+         * @brief Gets the vector's X component.
+         * @return Reference to the vector's X component.
+         */
+        constexpr T& Y() noexcept;
+
+        /**
+         * @brief Gets the vector's X component.
+         * @return Constant reference to the vector's X component.
+         */
+        constexpr const T& Z() const noexcept;
+
+        /**
+         * @brief Gets the vector's X component.
+         * @return Reference to the vector's X component.
+         */
+        constexpr T& Z() noexcept;
+
+        /**
+         * @brief Gets the vector's X component.
+         * @return Constant reference to the vector's X component.
+         */
+        constexpr const T& W() const noexcept;
+
+        /**
+         * @brief Gets the vector's X component.
+         * @return Reference to the vector's X component.
+         */
+        constexpr T& W() noexcept;
+
+        /**
+         * @brief Computes the dot product (also known as the scalar or inner product) between the current vector and
+         *        the given one. The dot product calculates the projection of one of the vectors onto the other; the
+         *        order doesn't matter. On normalized vectors, the returned value represents the cosine of the angle
+         *        (in radians) between them.
+         * @tparam DotProductType The type of the result. For vectors of an integral type, it is defined to a large
+         *                        unsigned integer type to avoid overflows.
+         * @param vec Vector to compute the dot product with.
+         * @return The result of the dot product.
+         */
+        template <typename DotProductType = std::conditional_t<std::is_integral_v<T>, U64, T>>
+        constexpr DotProductType Dot(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Computes the cross product (also called the vector product) between the current vector and the given
+         *        one.
+         * @param vec The vector to compute the cross product with.
+         * @return Computed orthogonal vector.
+         */
+        constexpr Vector Cross(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Reflects the current vector according to the given normal.
+         * @param normal Direction of the normal vector to compute the reflection with.
+         * @return The vector reflected according to the normal.
+         */
+        constexpr Vector Reflect(const Vector& normal) const noexcept;
+
+        /**
+         * @brief Computes the square length of the vector. This is faster than @ref ComputeLength because it does not
+         *        involve a square root, and therefore should be preferred over @ref ComputeLength in most calculations.
+         * @tparam SquareLengthType The type of the result. For vectors of an integral type, it is defined to a large
+         *                          unsigned integer type to avoid overflows.
+         * @return The squared length of the vector.
+         */
+        template <typename SquareLengthType = std::conditional_t<std::is_integral_v<T>, U64, T>>
+        constexpr SquareLengthType ComputeSquaredLength() const noexcept;
+
+        /**
+         * @brief Computes the length of the vector. This is slower than @ref ComputeSquaredLength because it involves
+         *        a square root.
+         * @tparam LengthType The type of the result. For vectors of an integral type, it is defined to a large unsigned
+         *                    integer type to avoid overflows.
+         * @return The length of the vector.
+         */
+        template <typename LengthType = std::conditional_t<std::is_integral_v<T>, U64, T>>
+        constexpr LengthType ComputeLength() const noexcept;
+
+        /**
+         * @brief Normalizes the current vector. Normalizing a vector makes it of length 1.
+         * @tparam NormalizedType The type of the normalized vector's values. For vectors of an integral type, it is
+         *                        defined to be a float.
+         * @return Normalized vector.
+         */
+        template <typename NormalizedType = std::conditional_t<std::is_integral_v<T>, F32, T>>
+        constexpr Vector<NormalizedType, Size> Normalize() const noexcept;
+
+        /**
+         * @brief Computes the linear interpolation of two vectors according to a coefficient.
+         * @tparam LerpType Type of the interpolated vector's values. By default, it is the same as the current vector's.
+         * @tparam CoeffType Type of the coefficient. For vectors of an integral type, it is defined to float; otherwise,
+         *                   it is the same as the original vectors'.
+         * @param vec Vector to be interpolated with.
+         * @param coeff Coefficient between 0 (returns the current vector) and 1 (returns the other vector).
+         * @return Linearly interpolated vector.
+         */
+        template <typename LerpType = T, typename CoeffType = std::conditional_t<std::is_integral_v<T>, F32, T>>
+        constexpr Vector<LerpType, Size> Lerp(const Vector& vec, CoeffType coeff) const noexcept;
+
+        /**
+         * @brief Computes the normalized linear interpolation of two vectors according to a coefficient.
+        * @tparam NormalizedType Type of the normalized interpolated vector's values. For vectors of an integral type,
+        *                        it is defined to float; otherwise, it is the same as the original vectors'.
+         * @tparam CoeffType Type of the coefficient. For vectors of an integral type, it is defined to float; otherwise,
+         *                   it is the same as the original vectors'.
+         * @param vec Vector to be interpolated with.
+         * @param coeff Coefficient between 0 (returns the normalized current vector) and 1 (returns the normalized
+         *              other vector).
+         * @return Normalized linearly interpolated vector.
+         */
+        template <typename NormalizedType = std::conditional_t<std::is_integral_v<T>, F32, T>,
+                  typename CoeffType = std::conditional_t<std::is_integral_v<T>, F32, T>>
+        constexpr Vector<NormalizedType, Size> NLerp(const Vector& vec, CoeffType coeff) const noexcept;
+
+        /**
+         * @brief Checks for strict equality between the current vector & the given one. (May return errors because of
+         *        floating-point imprecision).
+         * @param vec Vector to be compared with.
+         * @return Whether the two vectors are strictly equal to each other or not.
+         */
+        constexpr bool StrictlyEquals(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Computes the unique hash value of the vector.
+         * @param seed Value to use as a hash seed.
+         * @return Vector's hash.
+         */
+        [[nodiscard]] constexpr U64 Hash(U64 seed = 0) const noexcept;
+
+        /**
+         * @brief Default copy assignment operator.
+         * @return Reference to the copied vector.
+         */
+        constexpr Vector& operator=(const Vector&) noexcept = default;
+
+        /**
+         * @brief Default move assignment operator.
+         * @return Reference to the moved vector.
+         */
+        constexpr Vector& operator=(Vector&&) noexcept = default;
+
+        /**
+         * @brief Vector negation operator. This unary minus negates the components of the vector, reversing its
+         *        direction.
+         * @return Negated vector.
+         */
+        constexpr Vector operator-() const noexcept;
+
+        /**
+         * @brief Element-wise vector-vector addition operator.
+         * @param vec Vector to be added.
+         * @return Result of the summed vectors.
+         */
+        constexpr Vector operator+(const Vector& vec) const noexcept;
+
+        /**
+         * Element-wise vector-value addition operator.
+         * @param val Value to be added.
+         * @return Result of the vector summed with the value.
+         */
+        constexpr Vector operator+(T val) const noexcept;
+
+        /**
+         * @brief Element-wise vector-vector subtraction operator.
+         * @param vec Vector to be subtracted.
+         * @return Result of the subtraction.
+         */
+        constexpr Vector operator-(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Element-wise vector-value subtraction operator.
+         * @param val Value to be subtracted.
+         * @return Result of the subtraction.
+         */
+        constexpr Vector operator-(T val) const noexcept;
+
+        /**
+         * @brief Element-wise vector-vector multiplication operator (performs a [Hadamard product](https://en.wikipedia.org/wiki/Hadamard_product_(matrices)).
+         * @param vec Vector to be multiplied by.
+         * @return Result of the multiplication.
+         */
+        constexpr Vector operator*(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Element-wise vector-value multiplication operator.
+         * @param val Value to be multiplied by.
+         * @return Result of the multiplication.
+         */
+        constexpr Vector operator*(T val) const noexcept;
+
+        /**
+         * @brief Element-wise vector-vector division operator.
+         * @param vec Vector to be divided by.
+         * @return Result of the division.
+         */
+        constexpr Vector operator/(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Element-wise vector-value division operator.
+         * @param val Value to be divided by.
+         * @return Result of the division.
+         */
+        constexpr Vector operator/(T val) const noexcept;
+
+        /**
+         * @brief Element-wise vector-vector addition assignment operator.
+         * @param vec Vector to be added.
+         * @return Reference to the result of the summed vectors.
+         */
+        constexpr Vector& operator+=(const Vector& vec) const noexcept;
+
+        /**
+         * Element-wise vector-value addition assignment operator.
+         * @param val Value to be added.
+         * @return Reference to the result of the vector summed with the value.
+         */
+        constexpr Vector& operator+=(T val) const noexcept;
+
+        /**
+         * @brief Element-wise vector-vector subtraction assignment operator.
+         * @param vec Vector to be subtracted.
+         * @return Reference to the result of the subtraction.
+         */
+        constexpr Vector& operator-=(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Element-wise vector-value subtraction assignment operator.
+         * @param val Value to be subtracted.
+         * @return Reference to the result of the subtraction.
+         */
+        constexpr Vector& operator-=(T val) const noexcept;
+
+        /**
+         * @brief Element-wise vector-vector multiplication assignment operator (performs a [Hadamard product](https://en.wikipedia.org/wiki/Hadamard_product_(matrices)).
+         * @param vec Vector to be multiplied by.
+         * @return Reference to the result of the multiplication.
+         */
+        constexpr Vector& operator*=(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Element-wise vector-value multiplication assignment operator.
+         * @param val Value to be multiplied by.
+         * @return Reference to the result of the multiplication.
+         */
+        constexpr Vector& operator*=(T val) const noexcept;
+
+        /**
+         * @brief Element-wise vector-vector division assignment operator.
+         * @param vec Vector to be divided by.
+         * @return Reference to the result of the division.
+         */
+        constexpr Vector& operator/=(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Element-wise vector-value division assignment operator.
+         * @param val Value to be divided by.
+         * @return Reference to the result of the division.
+         */
+        constexpr Vector& operator/=(T val) const noexcept;
+
+        /**
+         * @brief Element indexing operator.
+         * @param index Element's index.
+         * @return Constant reference to the element at the given index.
+         */
+        constexpr const T& operator[](U64 index) const noexcept;
+
+        /**
+         * @brief Element indexing operator.
+         * @param index Element's index.
+         * @return Reference to the element at the given index.
+         */
+        constexpr T& operator[](U64 index) noexcept;
+
+        /**
+         * @brief Vector equality comparison operator. Uses a near-equality check on floating-point types to take
+         *        floating-point error into account.
+         * @param vec Vector to be compared with.
+         * @return Whether both vectors are nearly equal to each other or not.
+         */
+        constexpr bool operator==(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Vector inequality comparison operator. Uses a near-equality check on floating-point types to take
+         *        floating-point error into account.
+         * @param vec Vector to be compared with.
+         * @return Whether both vectors are different or not.
+         */
+        constexpr bool operator!=(const Vector& vec) const noexcept;
+
+        /**
+         * @brief Vector's value type conversion operator.
+         * @tparam To Type to convert the vector's values to.
+         * @result Vector with values of the new type.
+         */
+        template <typename To>
+        constexpr explicit operator Vector<To, Size>() const noexcept;
+
+        /**
+         * @brief Stream output operator.
+         * @param stream Stream to output to.
+         * @param vec Vector to output.
+         * @return The modified stream.
+         */
+        friend std::ostream& operator<<<>(std::ostream& stream, const Vector& vec);
+
+    private:
+        std::array<T, Size> m_Data{};
+    };
+
+    /**
+     * @brief Element-wise value-vector addition operator (of the form val + vec).
+     * @tparam T Type of the vector's data.
+     * @tparam Size Size of the vector.
+     * @param val Value to be added to the vector's elements.
+     * @param vec Vector to be added.
+     * @return Vector with the value added to its elements.
+     */
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> operator+(T val, const Vector<T, Size>& vec) noexcept;
+
+    /**
+     * @brief Element-wise value-vector multiplication operator (of the form val * vec).
+     * @tparam T Type of the vector's data.
+     * @tparam Size Size of the vector.
+     * @param val Value to multiply the vector's elements by.
+     * @param vec Vector to be multiplied.
+     * @return Vector with its elements multiplied by the value.
+     */
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> operator*(T val, const Vector<T, Size>& vec) noexcept;
+
+    // Deduction guides
+
+    template <typename T, typename... Args>
+    Vector(T, Args... args) -> Vector<T, sizeof...(Args) + 1>;
+
+    // Aliases
+    template <typename T>
+    using Vec2 = Vector<T, 2>;
+
+    template <typename T>
+    using Vec3 = Vector<T, 3>;
+
+    template <typename T>
+    using Vec4 = Vector<T, 4>;
+
+    using Vec2b = Vec2<U8>;
+    using Vec3b = Vec3<U8>;
+    using Vec4b = Vec4<U8>;
+
+    using Vec2i = Vec2<I32>;
+    using Vec3i = Vec3<I32>;
+    using Vec4i = Vec4<I32>;
+
+    using Vec2u = Vec2<U32>;
+    using Vec3u = Vec3<U32>;
+    using Vec4u = Vec4<U32>;
+
+    using Vec2f = Vec2<F32>;
+    using Vec3f = Vec3<F32>;
+    using Vec4f = Vec4<F32>;
+
+    using Vec2d = Vec2<F64>;
+    using Vec3d = Vec3<F64>;
+    using Vec4d = Vec4<F64>;
+
+    namespace Axis {
+        constexpr Vec3f X(1.0f, 0.0f, 0.0f);
+        constexpr Vec3f Y(0.0f, 1.0f, 0.0f);
+        constexpr Vec3f Z(0.0f, 0.0f, 1.0f);
+    }
+
+    /**
+     * @brief Vector element fetching function for a constant lvalue reference.
+     * @tparam I Index of the element.
+     * @tparam T Type of the vector's elements.
+     * @tparam Size Size of the vector.
+     * @param vec Vector to get the element from.
+     * @return Constant lvalue reference on the vector's element.
+     */
+    template <U64 I, typename T, U64 Size>
+    constexpr const T& Get(const Vector<T, Size>& vec);
+
+    /**
+     * @brief Vector element fetching function for a non-constant lvalue reference.
+     * @tparam I Index of the element.
+     * @tparam T Type of the vector's elements.
+     * @tparam Size Size of the vector.
+     * @param vec Vector to get the element from.
+     * @return Non-constant lvalue reference on the vector's element.
+     */
+    template <U64 I, typename T, U64 Size>
+    constexpr T& Get(const Vector<T, Size>& vec);
+
+    /**
+     * @brief Vector element fetching function for a non-constant rvalue reference.
+     * @tparam I Index of the element.
+     * @tparam T Type of the vector's elements.
+     * @tparam Size Size of the vector.
+     * @param vec Vector to get the element from.
+     * @return Non-constant rvalue reference on the vector's element.
+     */
+    template <U64 I, typename T, U64 Size>
+    constexpr T&& Get(const Vector<T, Size>& vec);
+}
+
+/**
+ * @brief Specialization of std::tuple_size for @ref Fl::Vector.
+ * @tparam T Type of the vector's elements.
+ * @tparam Size Size of the vector.
+ */
+template <typename T, Fl::U64 Size>
+struct std::tuple_size<Fl::Vector<T, Size>> : std::integral_constant<Fl::U64, Size> {};
+
+/**
+ * @brief Specialization of std::tuple_element for @ref Fl::Vector.
+ * @tparam I Index of the element.
+ * @tparam T Type of the vector's elements.
+ * @tparam Size Size of the vector.
+ */
+template <std::size_t I, typename T, Fl::U64 Size>
+struct std::tuple_element<I, Fl::Vector<T, Size>> {
+    using type = T;
+};
+
+/**
+ * @brief Specialization of std::hash for @ref Fl::Vector.
+ * @tparam T Type of the vector's elements.
+ * @tparam Size Size of the vector.
+ */
+template <typename T, Fl::U64 Size>
+struct std::hash<Fl::Vector<T, Size>> {
+    /**
+     * @brief Computes the hash of the given vector.
+     * @param vec Vector to compute the hash for.
+     * @return Vector's hash value.
+     */
+    constexpr std::size_t operator()(const Fl::Vector<T, Size>& vec) const noexcept;
+};
+
+/**
+ * @brief Specialization of std::equal_to for @ref Fl::Vector. This performs a strict equality check.
+ * @tparam T Type of the vector's elements.
+ * @tparam Size Size of the vector.
+ */
+template <typename T, Fl::U64 Size>
+struct std::equal_to<Fl::Vector<T, Size>> {
+    /**
+     * @brief Checks that the two given vectors are strictly equal to each other.
+     * @param vec1 First vector to compare.
+     * @param vec2 Second vector to compare.
+     * @return Whether both vectors are equal to each other or not.
+     */
+    constexpr std::size_t operator()(const Fl::Vector<T, Size>& vec1, const Fl::Vector<T, Size>& vec2) const noexcept;
+};
+
+/**
+ * @brief Specialization of std::less for @ref Fl::Vector.
+ * @tparam T Type of the vector's elements.
+ * @tparam Size Size of the vector.
+ */
+template <typename T, Fl::U64 Size>
+struct std::less<Fl::Vector<T, Size>> {
+    /**
+     * @brief Checks that the first given vector is strictly less than the other.
+     * @param vec1 First vector to compare.
+     * @param vec2 Second vector to compare.
+     * @return Whether the first vector is strictly less than the other or not.
+     */
+    constexpr bool operator()(const Fl::Vector<T, Size>& vec1, const Fl::Vector<T, Size>& vec2) const noexcept;
+};
+
+#include <FlashlightEngine/Math/Vector.inl>
+
+#endif // FL_MATH_VECTOR_HPP

--- a/Include/FlashlightEngine/Math/Vector.inl
+++ b/Include/FlashlightEngine/Math/Vector.inl
@@ -34,12 +34,6 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    template <typename... Args, typename, typename>
-    constexpr Vector<T, Size>::Vector(Args&&... args) noexcept
-        : m_Data{static_cast<T>(args)...} {
-    }
-
-    template <typename T, U64 Size>
     constexpr U64 Vector<T, Size>::GetSize() const noexcept {
         return Size;
     }
@@ -293,7 +287,7 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    constexpr Vector<T, Size>& Vector<T, Size>::operator+=(const Vector& vec) const noexcept {
+    constexpr Vector<T, Size>& Vector<T, Size>::operator+=(const Vector& vec) noexcept {
         for (U64 i = 0; i < Size; i++) {
             m_Data[i] += vec[i];
         }
@@ -302,7 +296,7 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    constexpr Vector<T, Size>& Vector<T, Size>::operator+=(T val) const noexcept {
+    constexpr Vector<T, Size>& Vector<T, Size>::operator+=(T val) noexcept {
         for (T& element : m_Data) {
             element += val;
         }
@@ -311,7 +305,7 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    constexpr Vector<T, Size>& Vector<T, Size>::operator-=(const Vector& vec) const noexcept {
+    constexpr Vector<T, Size>& Vector<T, Size>::operator-=(const Vector& vec) noexcept {
         for (U64 i = 0; i < Size; i++) {
             m_Data[i] -= vec[i];
         }
@@ -320,7 +314,7 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    constexpr Vector<T, Size>& Vector<T, Size>::operator-=(T val) const noexcept {
+    constexpr Vector<T, Size>& Vector<T, Size>::operator-=(T val) noexcept {
         for (T& element : m_Data) {
             element -= val;
         }
@@ -329,7 +323,7 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    constexpr Vector<T, Size>& Vector<T, Size>::operator*=(const Vector& vec) const noexcept {
+    constexpr Vector<T, Size>& Vector<T, Size>::operator*=(const Vector& vec) noexcept {
         for (U64 i = 0; i < Size; i++) {
             m_Data[i] *= vec[i];
         }
@@ -338,7 +332,7 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    constexpr Vector<T, Size>& Vector<T, Size>::operator*=(T val) const noexcept {
+    constexpr Vector<T, Size>& Vector<T, Size>::operator*=(T val) noexcept {
         for (T& element : m_Data) {
             element *= val;
         }
@@ -347,10 +341,10 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    constexpr Vector<T, Size>& Vector<T, Size>::operator/=(const Vector& vec) const noexcept {
-        if constexpr (std::is_integral_v<T>)
-            FlAssert(std::find(vec.m_Data.cbegin(), vec.m_Data.cend(), 0) == vec.m_Data.cend(),
-                     "Division by 0 is undefined.");
+    constexpr Vector<T, Size>& Vector<T, Size>::operator/=(const Vector& vec) noexcept {
+        if constexpr (std::is_integral_v<T>) {
+            FlAssert(std::find(vec.m_Data.cbegin(), vec.m_Data.cend(), 0) == vec.m_Data.cend(), "Integer division by 0 is undefined.");
+        }
 
         for (U64 i = 0; i < Size; i++) {
             m_Data[i] /= vec[i];
@@ -360,9 +354,10 @@ namespace Fl {
     }
 
     template <typename T, U64 Size>
-    constexpr Vector<T, Size>& Vector<T, Size>::operator/=(T val) const noexcept {
-        if constexpr (std::is_integral_v<T>)
-            FlAssert(val != 0, "Division by 0 is undefined.");
+    constexpr Vector<T, Size>& Vector<T, Size>::operator/=(T val) noexcept {
+        if constexpr (std::is_integral_v<T>) {
+            FlAssert(val != 0, "Integer division by 0 is undefined.");
+        }
 
         for (T& element : m_Data) {
             element /= val;
@@ -385,9 +380,9 @@ namespace Fl {
     constexpr bool Vector<T, Size>::operator==(const Vector& vec) const noexcept {
         if constexpr (std::is_floating_point_v<T>) {
             return FloatMath::AreNearlyEqual(*this, vec);
+        } else {
+            return StrictlyEquals(vec);
         }
-
-        return StrictlyEquals(vec);
     }
 
     template <typename T, U64 Size>
@@ -433,19 +428,19 @@ namespace Fl {
     }
 
     template <U64 I, typename T, U64 Size>
-    constexpr const T& Get(const Vector<T, Size>& vec) {
+    constexpr const T& get(const Vector<T, Size>& vec) {
         static_assert(I < Size);
         return vec[I];
     }
 
     template <U64 I, typename T, U64 Size>
-    constexpr T& Get(const Vector<T, Size>& vec) {
+    constexpr T& get(Vector<T, Size>& vec) {
         static_assert(I < Size);
         return vec[I];
     }
 
     template <U64 I, typename T, U64 Size>
-    constexpr T&& Get(const Vector<T, Size>& vec) {
+    constexpr T&& get(Vector<T, Size>&& vec) {
         static_assert(I < Size);
         return std::move(vec[I]);
     }

--- a/Include/FlashlightEngine/Math/Vector.inl
+++ b/Include/FlashlightEngine/Math/Vector.inl
@@ -1,0 +1,477 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#include <FlashlightEngine/Core/Assert.hpp>
+#include <FlashlightEngine/Math/FloatMath.hpp>
+
+#include <algorithm>
+
+namespace Fl {
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>::Vector(const Vector<T, Size + 1>& vec) noexcept {
+        for (U64 i = 0; i < Size; i++) {
+            m_Data[i] = vec[i];
+        }
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>::Vector(const Vector<T, Size - 1>& vec, T val) noexcept {
+        for (U64 i = 0; i < Size - 1; i++) {
+            m_Data[i] = vec[i];
+        }
+
+        m_Data.back() = val;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>::Vector(T val) noexcept {
+        for (T& element : m_Data) {
+            element = val;
+        }
+    }
+
+    template <typename T, U64 Size>
+    template <typename... Args, typename, typename>
+    constexpr Vector<T, Size>::Vector(Args&&... args) noexcept
+        : m_Data{static_cast<T>(args)...} {
+    }
+
+    template <typename T, U64 Size>
+    constexpr U64 Vector<T, Size>::GetSize() const noexcept {
+        return Size;
+    }
+
+    template <typename T, U64 Size>
+    constexpr const std::array<T, Size>& Vector<T, Size>::GetData() const noexcept {
+        return m_Data;
+    }
+
+    template <typename T, U64 Size>
+    constexpr std::array<T, Size>& Vector<T, Size>::GetData() noexcept {
+        return m_Data;
+    }
+
+    template <typename T, U64 Size>
+    constexpr const T* Vector<T, Size>::GetDataPtr() const noexcept {
+        return m_Data.data();
+    }
+
+    template <typename T, U64 Size>
+    constexpr T* Vector<T, Size>::GetDataPtr() noexcept {
+        return m_Data.data();
+    }
+
+    template <typename T, U64 Size>
+    constexpr const T& Vector<T, Size>::X() const noexcept {
+        static_assert(
+            Size >= 1, "[Error] Fl::Vector needs to have at least a size of 1 to have its X component retrieved.");
+        return m_Data[0];
+    }
+
+    template <typename T, U64 Size>
+    constexpr T& Vector<T, Size>::X() noexcept {
+        return const_cast<T&>(static_cast<const Vector*>(this)->X());
+    }
+
+    template <typename T, U64 Size>
+    constexpr const T& Vector<T, Size>::Y() const noexcept {
+        static_assert(
+            Size >= 2, "[Error] Fl::Vector needs to have at least a size of 2 to have its Y component retrieved.");
+        return m_Data[1];
+    }
+
+    template <typename T, U64 Size>
+    constexpr T& Vector<T, Size>::Y() noexcept {
+        return const_cast<T&>(static_cast<const Vector*>(this)->Y());
+    }
+
+    template <typename T, U64 Size>
+    constexpr const T& Vector<T, Size>::Z() const noexcept {
+        static_assert(
+            Size >= 3, "[Error] Fl::Vector needs to have at least a size of 3 to have its Z component retrieved.");
+        return m_Data[2];
+    }
+
+    template <typename T, U64 Size>
+    constexpr T& Vector<T, Size>::Z() noexcept {
+        return const_cast<T&>(static_cast<const Vector*>(this)->Z());
+    }
+
+    template <typename T, U64 Size>
+    constexpr const T& Vector<T, Size>::W() const noexcept {
+        static_assert(
+            Size >= 4, "[Error] Fl::Vector needs to have at least a size of 4 to have its W component retrieved.");
+        return m_Data[3];
+    }
+
+    template <typename T, U64 Size>
+    constexpr T& Vector<T, Size>::W() noexcept {
+        return const_cast<T&>(static_cast<const Vector*>(this)->W());
+    }
+
+    template <typename T, U64 Size>
+    template <typename DotProductType>
+    constexpr DotProductType Vector<T, Size>::Dot(const Vector& vec) const noexcept {
+        DotProductType result{};
+        for (U64 i = 0; i < Size; i++) {
+            result += static_cast<DotProductType>(m_Data[i]) * static_cast<DotProductType>(vec[i]);
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::Cross(const Vector& vec) const noexcept {
+        static_assert(Size == 3, "[Error] Both vectors must be 3 dimensional to compute their cross product.");
+        static_assert(std::is_signed_v<T>,
+                      "[Error] The cross product of vectors can only be computed with vectors of a signed type.");
+
+        Vector result;
+
+        result.m_Data[0] = m_Data[1] * vec.m_Data[2] - m_Data[2] * vec.m_Data[1];
+        result.m_Data[1] = -(m_Data[0] * vec.m_Data[2] - m_Data[2] * vec.m_Data[0]);
+        result.m_Data[2] = m_Data[0] * vec.m_Data[1] - m_Data[1] * vec.m_Data[0];
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::Reflect(const Vector& normal) const noexcept {
+        static_assert(std::is_signed_v<T>,
+                      "[Error] The reflection of a vector can only be computed with vectors of a signed type.");
+
+        return (*this - normal * static_cast<T>(Dot(normal)) * 2);
+    }
+
+    template <typename T, U64 Size>
+    template <typename SquareLengthType>
+    constexpr SquareLengthType Vector<T, Size>::ComputeSquaredLength() const noexcept {
+        return static_cast<SquareLengthType>(Dot(*this));
+    }
+
+    template <typename T, U64 Size>
+    template <typename LengthType>
+    constexpr LengthType Vector<T, Size>::ComputeLength() const noexcept {
+        return std::sqrt(static_cast<LengthType>(ComputeSquaredLength()));
+    }
+
+    template <typename T, U64 Size>
+    template <typename NormalizedType>
+    constexpr Vector<NormalizedType, Size> Vector<T, Size>::Normalize() const noexcept {
+        static_assert(std::is_floating_point_v<NormalizedType>,
+                      "[Error] The normalized vector's type must be floating-point.");
+
+        const NormalizedType sqLength = ComputeSquaredLength<NormalizedType>();
+        Vector<NormalizedType, Size> result(*this);
+
+        if (sqLength != static_cast<NormalizedType>(0)) {
+            result /= std::sqrt(sqLength);
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    template <typename LerpType, typename CoeffType>
+    constexpr Vector<LerpType, Size> Vector<T, Size>::Lerp(const Vector& vec, CoeffType coeff) const noexcept {
+        static_assert(std::is_floating_point_v<CoeffType>,
+                      "[Error] The linear interpolation coefficient type must be floating-point.");
+        FlAssert(coeff >= 0 && coeff <= 1, "The interpolation coefficient must be between 0 & 1.");
+
+        const Vector<CoeffType, Size> convertedThis(*this);
+        const Vector<CoeffType, Size> lerpVec = convertedThis + (Vector<CoeffType, Size>(vec) - convertedThis) * coeff;
+
+        return Vector<LerpType, Size>(lerpVec);
+    }
+
+    template <typename T, U64 Size>
+    template <typename NormalizedType, typename CoeffType>
+    constexpr Vector<NormalizedType, Size> Vector<T, Size>::NLerp(const Vector& vec, CoeffType coeff) const noexcept {
+        return Lerp<NormalizedType>(vec, coeff).Normalize();
+    }
+
+    template <typename T, U64 Size>
+    constexpr bool Vector<T, Size>::StrictlyEquals(const Vector& vec) const noexcept {
+        return std::equal(m_Data.cbegin(), m_Data.cend(), vec.m_Data.cbegin());
+    }
+
+    template <typename T, U64 Size>
+    constexpr U64 Vector<T, Size>::Hash(U64 seed) const noexcept {
+        std::hash<T> hasher{};
+
+        for (const T& element : m_Data) {
+            seed ^= hasher(element) + 0x9e3779b9 + (seed << 6u) + (seed >> 2u);
+        }
+
+        return seed;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator-() const noexcept {
+        Vector result;
+
+        for (U64 i = 0; i < Size; i++) {
+            result[i] = -m_Data[i];
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator+(const Vector& vec) const noexcept {
+        Vector result = *this;
+
+        result += vec;
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator+(T val) const noexcept {
+        Vector result = *this;
+
+        result += val;
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator-(const Vector& vec) const noexcept {
+        Vector result = *this;
+
+        result -= vec;
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator-(T val) const noexcept {
+        Vector result = *this;
+
+        result -= val;
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator*(const Vector& vec) const noexcept {
+        Vector result = *this;
+
+        result *= vec;
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator*(T val) const noexcept {
+        Vector result = *this;
+
+        result *= val;
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator/(const Vector& vec) const noexcept {
+        Vector result = *this;
+
+        result /= vec;
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> Vector<T, Size>::operator/(T val) const noexcept {
+        Vector result = *this;
+
+        result /= val;
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>& Vector<T, Size>::operator+=(const Vector& vec) const noexcept {
+        for (U64 i = 0; i < Size; i++) {
+            m_Data[i] += vec[i];
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>& Vector<T, Size>::operator+=(T val) const noexcept {
+        for (T& element : m_Data) {
+            element += val;
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>& Vector<T, Size>::operator-=(const Vector& vec) const noexcept {
+        for (U64 i = 0; i < Size; i++) {
+            m_Data[i] -= vec[i];
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>& Vector<T, Size>::operator-=(T val) const noexcept {
+        for (T& element : m_Data) {
+            element -= val;
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>& Vector<T, Size>::operator*=(const Vector& vec) const noexcept {
+        for (U64 i = 0; i < Size; i++) {
+            m_Data[i] *= vec[i];
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>& Vector<T, Size>::operator*=(T val) const noexcept {
+        for (T& element : m_Data) {
+            element *= val;
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>& Vector<T, Size>::operator/=(const Vector& vec) const noexcept {
+        if constexpr (std::is_integral_v<T>)
+            FlAssert(std::find(vec.m_Data.cbegin(), vec.m_Data.cend(), 0) == vec.m_Data.cend(),
+                     "Division by 0 is undefined.");
+
+        for (U64 i = 0; i < Size; i++) {
+            m_Data[i] /= vec[i];
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size>& Vector<T, Size>::operator/=(T val) const noexcept {
+        if constexpr (std::is_integral_v<T>)
+            FlAssert(val != 0, "Division by 0 is undefined.");
+
+        for (T& element : m_Data) {
+            element /= val;
+        }
+
+        return *this;
+    }
+
+    template <typename T, U64 Size>
+    constexpr const T& Vector<T, Size>::operator[](const U64 index) const noexcept {
+        return m_Data[index];
+    }
+
+    template <typename T, U64 Size>
+    constexpr T& Vector<T, Size>::operator[](const U64 index) noexcept {
+        return m_Data[index];
+    }
+
+    template <typename T, U64 Size>
+    constexpr bool Vector<T, Size>::operator==(const Vector& vec) const noexcept {
+        if constexpr (std::is_floating_point_v<T>) {
+            return FloatMath::AreNearlyEqual(*this, vec);
+        }
+
+        return StrictlyEquals(vec);
+    }
+
+    template <typename T, U64 Size>
+    constexpr bool Vector<T, Size>::operator!=(const Vector& vec) const noexcept {
+        return !(*this == vec);
+    }
+
+    template <typename T, U64 Size>
+    template <typename To>
+    constexpr Vector<T, Size>::operator Vector<To, Size>() const noexcept {
+        Vector<To, Size> result;
+
+        for (U64 i = 0; i < Size; i++) {
+            result[i] = static_cast<To>(m_Data[i]);
+        }
+
+        return result;
+    }
+
+    template <typename T, U64 Size>
+    std::ostream& operator<<(std::ostream& stream, const Vector<T, Size>& vec) {
+        using PrintType = std::conditional_t<std::is_same_v<T, U8>, I32, T>;
+
+        stream << "[ " << static_cast<PrintType>(vec[0]);
+
+        for (U64 i = 1; i < Size; i++) {
+            stream << ", " << static_cast<PrintType>(vec[i]);
+        }
+
+        stream << " ]";
+
+        return stream;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> operator+(T val, const Vector<T, Size>& vec) noexcept {
+        return vec + val;
+    }
+
+    template <typename T, U64 Size>
+    constexpr Vector<T, Size> operator*(T val, const Vector<T, Size>& vec) noexcept {
+        return vec * val;
+    }
+
+    template <U64 I, typename T, U64 Size>
+    constexpr const T& Get(const Vector<T, Size>& vec) {
+        static_assert(I < Size);
+        return vec[I];
+    }
+
+    template <U64 I, typename T, U64 Size>
+    constexpr T& Get(const Vector<T, Size>& vec) {
+        static_assert(I < Size);
+        return vec[I];
+    }
+
+    template <U64 I, typename T, U64 Size>
+    constexpr T&& Get(const Vector<T, Size>& vec) {
+        static_assert(I < Size);
+        return std::move(vec[I]);
+    }
+}
+
+template <typename T, Fl::U64 Size>
+constexpr std::size_t std::hash<Fl::Vector<T, Size>>::operator()(const Fl::Vector<T, Size>& vec) const noexcept {
+    return vec.Hash();
+}
+
+template <typename T, Fl::U64 Size>
+constexpr std::size_t std::equal_to<Fl::Vector<T, Size>>::operator()(const Fl::Vector<T, Size>& vec1,
+                                                                     const Fl::Vector<T, Size>& vec2) const noexcept {
+    return vec1.StrictlyEquals(vec2);
+}
+
+template <typename T, Fl::U64 Size>
+constexpr bool std::less<Fl::Vector<T, Size>>::operator()(const Fl::Vector<T, Size>& vec1,
+                                                          const Fl::Vector<T, Size>& vec2) const noexcept {
+    for (Fl::U64 i = 0; i < Size; i++) {
+        if (vec1[i] == vec2[i]) {
+            continue;
+        }
+
+        return (vec1[i] < vec2[i]);
+    }
+
+    return false;
+}

--- a/Include/FlashlightEngine/Prerequisites.hpp
+++ b/Include/FlashlightEngine/Prerequisites.hpp
@@ -11,10 +11,18 @@
 
 #if defined(_MSC_VER)
 #   define FL_COMPILER_MSVC
-#elif defined(__gnuc__)
+#elif defined(__GNUC__)
 #   define FL_COMPILER_GCC
+
+#   ifdef (__MINGW32__)
+#       define FL_COMPILER_MINGW
+#   endif
 #elif defined(__clang__)
 #   define FL_COMPILER_CLANG
+
+#   ifdef (__MINGW32__)
+#       define FL_COMPILER_MINGW
+#   endif
 #else
 #   define FL_COMPILER_UNKNOWN
 #   error Could not determine the used compiler.
@@ -24,6 +32,7 @@
 #   define FL_PLATFORM_WINDOWS
 #elif defined(__linux__)
 #   define FL_PLATFORM_LINUX
+#   define FL_PLATFORM_POSIX
 #else
 #   define FL_PLATFORM_UNKNOWN
 #   error Could not determine the target platform.

--- a/Include/FlashlightEngine/Prerequisites.hpp
+++ b/Include/FlashlightEngine/Prerequisites.hpp
@@ -9,6 +9,26 @@
 
 #include <cstdint>
 
+#if defined(_MSC_VER)
+#   define FL_COMPILER_MSVC
+#elif defined(__gnuc__)
+#   define FL_COMPILER_GCC
+#elif defined(__clang__)
+#   define FL_COMPILER_CLANG
+#else
+#   define FL_COMPILER_UNKNOWN
+#   error Could not determine the used compiler.
+#endif
+
+#if defined(_WIN32)
+#   define FL_PLATFORM_WINDOWS
+#elif defined(__linux__)
+#   define FL_PLATFORM_LINUX
+#else
+#   define FL_PLATFORM_UNKNOWN
+#   error Could not determine the target platform.
+#endif
+
 namespace Fl {
     using I8 = int8_t;
     using I16 = int16_t;

--- a/Include/FlashlightEngine/Prerequisites.hpp
+++ b/Include/FlashlightEngine/Prerequisites.hpp
@@ -14,13 +14,13 @@
 #elif defined(__GNUC__)
 #   define FL_COMPILER_GCC
 
-#   ifdef (__MINGW32__)
+#   if defined(__MINGW32__)
 #       define FL_COMPILER_MINGW
 #   endif
 #elif defined(__clang__)
 #   define FL_COMPILER_CLANG
 
-#   ifdef (__MINGW32__)
+#   if defined(__MINGW32__)
 #       define FL_COMPILER_MINGW
 #   endif
 #else

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ depends on the main engine target, so when you will try to build the `FlTests` t
   - [ ] Cubemap
   - [ ] Normal mapping
 - [ ] Custom math library
-  - [ ] Vector class
-  - [ ] Matrix class
-  - [ ] Quaternion class
-  - [ ] Transform entity component
-  - [ ] Angle units classes
+  - [X] Vector class
+  - [X] Matrix class
+  - [X] Quaternion class
+  - [X] Transform entity component
+  - [X] Angle units classes
   - [X] Some constants
+  - [X] Some utilities (linear interpolation, smooth step, etc.)
 - [ ] Physics
 - [ ] Animations
 - [ ] Model loading

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ depends on the main engine target, so when you will try to build the `FlTests` t
   - [ ] Quaternion class
   - [ ] Transform entity component
   - [ ] Angle units classes
+  - [X] Some constants
 - [ ] Physics
 - [ ] Animations
 - [ ] Model loading

--- a/Source/FlashlightEngine/Math/Transform.cpp
+++ b/Source/FlashlightEngine/Math/Transform.cpp
@@ -67,6 +67,8 @@ namespace Fl {
 		m_Scale.X() *= x;
 		m_Scale.Y() *= y;
 		m_Scale.Z() *= z;
+
+		m_Updated = true;
 	}
 
 	Fl::Mat4f Transform::ComputeTranslationMatrix(const bool reverseTranslation) const {

--- a/Source/FlashlightEngine/Math/Transform.cpp
+++ b/Source/FlashlightEngine/Math/Transform.cpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#include <FlashlightEngine/Math/Transform.hpp>
+
+#include <FlashlightEngine/Core/Assert.hpp>
+#include <FlashlightEngine/Math/Angle.hpp>
+#include <FlashlightEngine/Math/Matrix.hpp>
+
+namespace Fl {
+	void Transform::SetPosition(const Vec3f& position) {
+		m_Position = position;
+		m_Updated = true;
+	}
+
+	void Transform::SetRotation(const Quaternionf& rotation) {
+		m_Rotation = rotation;
+		m_Updated = true;
+	}
+	
+	void Transform::SetRotation(Radiansf angle, const Vec3f& axis) {
+		SetRotation(Quaternionf(angle, axis));
+	}
+
+	void Transform::SetScale(const Vec3f& scale) {
+		m_Scale = scale;
+		m_Updated = true;
+	}
+
+	void Transform::Translate(const F32 x, const F32 y, const F32 z) {
+		m_Position.X() += x;
+		m_Position.Y() += y;
+		m_Position.Z() += z;
+
+		m_Updated = true;
+	}
+
+	void Transform::Rotate(const Quaternionf& rotation) {
+		m_Rotation *= rotation;
+		m_Updated = true;
+	}
+
+	void Transform::Rotate(const Radiansf angle, const Vec3f& axis) {
+		FlAssert(FloatMath::AreNearlyEqual(axis.ComputeSquaredLength(), 1.f), "Rotation axis must be normalized.");
+		Rotate(Quaternionf(angle, axis));
+	}
+
+	void Transform::Rotate(const Radiansf xAngle, const Radiansf yAngle) {
+		const Quaternionf xQuat(xAngle, Axis::X);
+		const Quaternionf yQuat(yAngle, Axis::Y);
+		m_Rotation = yQuat * m_Rotation * xQuat;
+
+		m_Updated = true;
+	}
+
+	void Transform::Rotate(const Radiansf xAngle, const Radiansf yAngle, const Radiansf zAngle) {
+		const Quaternionf xQuat(xAngle, Axis::X);
+		const Quaternionf yQuat(yAngle, Axis::Y);
+		const Quaternionf zQuat(zAngle, Axis::Z);
+		m_Rotation *= zQuat * xQuat * yQuat;
+
+		m_Updated = true;
+	}
+
+	void Transform::Scale(const F32 x, const F32 y, const F32 z) {
+		m_Scale.X() *= x;
+		m_Scale.Y() *= y;
+		m_Scale.Z() *= z;
+	}
+
+	Fl::Mat4f Transform::ComputeTranslationMatrix(const bool reverseTranslation) const {
+		const Vec3f translation = reverseTranslation ? -m_Position : m_Position;
+		const Mat4f translationMat(1.f, 0.f, 0.f, translation.X(),
+			                       0.f, 1.f, 0.f, translation.Y(),
+			                       0.f, 0.f, 1.f, translation.Z(),
+			                       0.f, 0.f, 0.f, 1.f);
+
+		return translationMat;
+	}
+
+	Fl::Mat4f Transform::ComputeTransformMatrix() const {
+		const Mat4f scaleMat(m_Scale.X(), 0.0f,        0.f,         0.f,
+			                 0.f,         m_Scale.Y(), 0.f,         0.f,
+			                 0.f,         0.f,         m_Scale.Z(), 0.f,
+			                 0.f,         0.f,         0.f,         1.f);
+
+		return ComputeTranslationMatrix() * m_Rotation.ComputeMatrix() * scaleMat;
+	}
+}

--- a/tests/Include/FlTests/CustomMatchers.hpp
+++ b/tests/Include/FlTests/CustomMatchers.hpp
@@ -80,7 +80,7 @@ public:
      * @param base Base vector to compare to.
      * @return True if values are nearly equal to each other, false otherwise.
      */
-    constexpr bool match(const T& base) const override;
+    constexpr bool match(const Fl::Vector<T, Size>& base) const override;
 
     /**
      * @brief Gets the description of the error if the match failed.

--- a/tests/Include/FlTests/CustomMatchers.hpp
+++ b/tests/Include/FlTests/CustomMatchers.hpp
@@ -1,0 +1,190 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_TESTS_CUSTOMMATCHERS_HPP
+#define FL_TESTS_CUSTOMMATCHERS_HPP
+
+#include <FlashlightEngine/Math/FloatMath.hpp>
+
+#include <catch2/matchers/catch_matchers.hpp>
+
+#include <sstream>
+
+/**
+ * @brief Custom Catch matcher, which checks for near-equality between floating point values.
+ * @tparam T Type of the value to be compared to.
+ * @tparam ToleranceType Tolerance type, which may differ from the value type.
+ */
+template <typename T, typename ToleranceType = T>
+class IsNearlyEqualTo final : public Catch::Matchers::MatcherBase<T> {
+    static_assert(std::is_floating_point_v<T>, "[Error] IsNearlyEqualTo's value type must be floating-point.");
+    static_assert(std::is_floating_point_v<ToleranceType>,
+                  "[Error] IsNearlyEqualTo's tolerance type must be floating-point.");
+
+public:
+    /**
+     * @brief Creates an instance of a near-equality check custom matcher.
+     * @param comparison Value to be compared with.
+     * @param absoluteTolerance Absolute tolerance to compare the values with.
+     */
+    constexpr explicit IsNearlyEqualTo(T comparison,
+                                       ToleranceType absoluteTolerance = std::numeric_limits<ToleranceType>::epsilon());
+
+    /**
+     * @brief Checks if the given value is nearly equal to the comparison one.
+     * @param base Base value to compare to.
+     * @return True if values are nearly equal to each other, false otherwise.
+     */
+    constexpr bool match(const T& base) const override;
+
+    /**
+     * @brief Gets the description of the error if the match failed.
+     * @return Error string to be printed.
+     */
+    std::string describe() const override;
+
+private:
+    T m_Comparison;
+    ToleranceType m_AbsoluteTolerance;
+};
+
+template <typename T, typename ToleranceType>
+IsNearlyEqualTo(T, ToleranceType) -> IsNearlyEqualTo<T, ToleranceType>;
+
+/**
+ * @brief Custom Catch matcher, which checks for near-equality between floating point vectors' values.
+ * @tparam T Type of the vector to be compared to.
+ * @tparam ToleranceType Tolerance type, which may differ from the value type.
+ */
+template <typename T, Fl::U64 Size, typename ToleranceType = T>
+class IsNearlyEqualToVector final : public Catch::Matchers::MatcherBase<Fl::Vector<T, Size>> {
+    static_assert(std::is_floating_point_v<T>, "[Error] IsNearlyEqualToVector's value type must be floating-point.");
+    static_assert(std::is_floating_point_v<ToleranceType>,
+                  "[Error] IsNearlyEqualToVector's tolerance type must be floating-point.");
+
+public:
+    /**
+     * @brief Creates an instance of a near-equality vector check custom matcher.
+     * @param comparison Vector to be compared with.
+     * @param absoluteTolerance Absolute tolerance to compare the values with.
+     */
+    constexpr explicit IsNearlyEqualToVector(const Fl::Vector<T, Size>& comparison,
+                                             ToleranceType absoluteTolerance
+                                             = std::numeric_limits<ToleranceType>::epsilon());
+
+    /**
+     * @brief Checks if the given vector has nearly equal values compared to the comparison one.
+     * @param base Base vector to compare to.
+     * @return True if values are nearly equal to each other, false otherwise.
+     */
+    constexpr bool match(const T& base) const override;
+
+    /**
+     * @brief Gets the description of the error if the match failed.
+     * @return Error string to be printed.
+     */
+    std::string describe() const override;
+
+private:
+    Fl::Vector<T, Size> m_Base;
+    Fl::Vector<T, Size> m_Comparison;
+    ToleranceType m_AbsoluteTolerance;
+};
+
+template <typename T, Fl::U64 Size, typename ToleranceType>
+IsNearlyEqualToVector(Fl::Vector<T, Size>, ToleranceType) -> IsNearlyEqualToVector<T, Size, ToleranceType>;
+
+/**
+ * @brief Custom Catch matcher, which checks for near-equality between floating point matrices' values.
+ * @tparam T Type of the matrix to be compared to.
+ * @tparam Width Width of the matrices to be compared.
+ * @tparam Height Height of the matrices to be compared.
+ * @tparam ToleranceType Tolerance type, which may differ from the value type.
+ */
+template <typename T, Fl::U64 Width, Fl::U64 Height, typename ToleranceType = T>
+class IsNearlyEqualToMatrix final : public Catch::Matchers::MatcherBase<Fl::Matrix<T, Width, Height>> {
+    static_assert(std::is_floating_point_v<T>, "[Error] IsNearlyEqualTo's value type must be floating-point.");
+    static_assert(std::is_floating_point_v<ToleranceType>,
+                  "[Error] IsNearlyEqualTo's tolerance type must be floating-point.");
+
+public:
+    /**
+     * @brief Creates an instance of a near-equality matrix check custom matcher.
+     * @param comparison Matrix to be compared with.
+     * @param absoluteTolerance Absolute tolerance to compare the values with.
+     */
+    constexpr explicit IsNearlyEqualToMatrix(const Fl::Matrix<T, Width, Height>& comparison,
+                                             ToleranceType absoluteTolerance
+                                             = std::numeric_limits<ToleranceType>::epsilon());
+
+    /**
+     * @brief Checks if the given matrix has nearly equal values compared to the comparison one.
+     * @param base Base matrix to compare to.
+     * @return True if values are nearly equal to each other, false otherwise.
+     */
+    constexpr bool match(const T& base) const override;
+
+    /**
+     * @brief Gets the description of the error if the match failed.
+     * @return Error string to be printed.
+     */
+    std::string describe() const override;
+
+private:
+    Fl::Matrix<T, Width, Height> m_Base;
+    Fl::Matrix<T, Width, Height> m_Comparison;
+    ToleranceType m_AbsoluteTolerance;
+};
+
+template <typename T, Fl::U64 Width, Fl::U64 Height, typename ToleranceType = T>
+IsNearlyEqualToMatrix(Fl::Matrix<T, Width, Height>, ToleranceType) -> IsNearlyEqualToMatrix<T, Width, Height, ToleranceType>;
+
+/**
+ * @brief Custom Catch matcher, which checks for near-equality between floating point quaternions' values.
+ * @tparam T Type of the quaternion to be compared to.
+ * @tparam ToleranceType Tolerance type, which may differ from the value type.
+ */
+template <typename T, typename ToleranceType = T>
+class IsNearlyEqualToQuaternion final : public Catch::Matchers::MatcherBase<Fl::Quaternion<T>> {
+    static_assert(std::is_floating_point_v<T>, "[Error] IsNearlyEqualTo's value type must be floating-point.");
+    static_assert(std::is_floating_point_v<ToleranceType>,
+                  "[Error] IsNearlyEqualTo's tolerance type must be floating-point.");
+
+public:
+    /**
+     * @brief Creates an instance of a near-equality quaternion check custom matcher.
+     * @param comparison Quaternion to be compared with.
+     * @param absoluteTolerance Absolute tolerance to compare the values with.
+     */
+    constexpr explicit IsNearlyEqualToQuaternion(const Fl::Quaternion<T>& comparison,
+                                                 ToleranceType absoluteTolerance = std::numeric_limits<ToleranceType>::epsilon());
+
+    /**
+     * @brief Checks if the given value is nearly equal to the comparison one.
+     * @param base Base value to compare to.
+     * @return True if values are nearly equal to each other, false otherwise.
+     */
+    constexpr bool match(const Fl::Quaternion<T>& base) const override;
+
+    /**
+     * @brief Gets the description of the error if the match failed.
+     * @return Error string to be printed.
+     */
+    std::string describe() const override;
+
+private:
+    // m_Base needs an instantiation, since a Fl::Quaternion doesn't have a default constructor
+    Fl::Quaternion<T> m_Base = Fl::Quaternion<T>::Identity();
+    Fl::Quaternion<T> m_Comparison;
+    ToleranceType m_AbsoluteTolerance;
+};
+
+template <typename T, typename ToleranceType>
+IsNearlyEqualToQuaternion(Fl::Quaternion<T>, ToleranceType) -> IsNearlyEqualToQuaternion<T, ToleranceType>;
+
+#include <FlTests/CustomMatchers.inl>
+
+#endif // FL_TESTS_CUSTOMMATCHERS_HPP

--- a/tests/Include/FlTests/CustomMatchers.hpp
+++ b/tests/Include/FlTests/CustomMatchers.hpp
@@ -125,7 +125,7 @@ public:
      * @param base Base matrix to compare to.
      * @return True if values are nearly equal to each other, false otherwise.
      */
-    constexpr bool match(const T& base) const override;
+    constexpr bool match(const Fl::Matrix<T, Width, Height>& base) const override;
 
     /**
      * @brief Gets the description of the error if the match failed.

--- a/tests/Include/FlTests/CustomMatchers.inl
+++ b/tests/Include/FlTests/CustomMatchers.inl
@@ -57,8 +57,8 @@ constexpr IsNearlyEqualToMatrix<T, Width, Height, ToleranceType>::IsNearlyEqualT
 }
 
 template <typename T, Fl::U64 Width, Fl::U64 Height, typename ToleranceType>
-constexpr bool IsNearlyEqualToMatrix<T, Width, Height, ToleranceType>::match(const T& base) const {
-    const_cast<IsNearlyEqualToMatrix*>(this)->m_base = base;
+constexpr bool IsNearlyEqualToMatrix<T, Width, Height, ToleranceType>::match(const Fl::Matrix<T, Width, Height>& base) const {
+    const_cast<IsNearlyEqualToMatrix*>(this)->m_Base = base;
 
     return Fl::FloatMath::AreNearlyEqual(m_Base, m_Comparison, m_AbsoluteTolerance);
 }

--- a/tests/Include/FlTests/CustomMatchers.inl
+++ b/tests/Include/FlTests/CustomMatchers.inl
@@ -1,0 +1,122 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+template <typename T, typename ToleranceType>
+constexpr IsNearlyEqualTo<T, ToleranceType>::IsNearlyEqualTo(T comparison, ToleranceType absoluteTolerance)
+    : m_Comparison(comparison), m_AbsoluteTolerance(absoluteTolerance) {
+}
+
+template <typename T, typename ToleranceType>
+constexpr bool IsNearlyEqualTo<T, ToleranceType>::match(const T& base) const {
+    return Fl::FloatMath::AreNearlyEqual(base, m_Comparison, m_AbsoluteTolerance);
+}
+
+template <typename T, typename ToleranceType>
+std::string IsNearlyEqualTo<T, ToleranceType>::describe() const {
+    std::ostringstream stream;
+    stream.precision(std::numeric_limits<T>::digits10 + 3);
+
+    stream << "is not nearly equal to " << m_Comparison;
+    return stream.str();
+}
+
+template <typename T, Fl::U64 Size, typename ToleranceType>
+constexpr IsNearlyEqualToVector<T, Size, ToleranceType>::IsNearlyEqualToVector(const Fl::Vector<T, Size>& comparison,
+                                                                               ToleranceType absoluteTolerance)
+    : m_Comparison{comparison}, m_AbsoluteTolerance{absoluteTolerance} {
+}
+
+template <typename T, Fl::U64 Size, typename ToleranceType>
+constexpr bool IsNearlyEqualToVector<T, Size, ToleranceType>::match(const T& base) const {
+    const_cast<IsNearlyEqualToVector*>(this)->m_Base = base;
+
+    return Fl::FloatMath::AreNearlyEqual(m_Base, m_Comparison, m_AbsoluteTolerance);
+}
+
+template <typename T, Fl::U64 Size, typename ToleranceType>
+std::string IsNearlyEqualToVector<T, Size, ToleranceType>::describe() const {
+    std::ostringstream stream;
+    stream.precision(std::numeric_limits<T>::digits10 + 3);
+
+    for (std::size_t i = 0; i < Size; ++i) {
+        if (!Fl::FloatMath::AreNearlyEqual(m_Base[i], m_Comparison[i], m_AbsoluteTolerance)) {
+            stream << "\n\tAt [" << i << "]: " << m_Base[i] << " is not nearly equal to " << m_Comparison[i];
+        }
+    }
+
+    return stream.str();
+}
+
+template <typename T, Fl::U64 Width, Fl::U64 Height, typename ToleranceType>
+constexpr IsNearlyEqualToMatrix<T, Width, Height, ToleranceType>::IsNearlyEqualToMatrix(
+    const Fl::Matrix<T, Width, Height>& comparison, ToleranceType absoluteTolerance)
+    : m_Comparison{comparison}, m_AbsoluteTolerance{absoluteTolerance} {
+}
+
+template <typename T, Fl::U64 Width, Fl::U64 Height, typename ToleranceType>
+constexpr bool IsNearlyEqualToMatrix<T, Width, Height, ToleranceType>::match(const T& base) const {
+    const_cast<IsNearlyEqualToMatrix*>(this)->m_base = base;
+
+    return Fl::FloatMath::AreNearlyEqual(m_Base, m_Comparison, m_AbsoluteTolerance);
+}
+
+template <typename T, Fl::U64 Width, Fl::U64 Height, typename ToleranceType>
+std::string IsNearlyEqualToMatrix<T, Width, Height, ToleranceType>::describe() const {
+    std::ostringstream stream;
+    stream.precision(std::numeric_limits<T>::digits10 + 3);
+
+    for (std::size_t widthIndex = 0; widthIndex < Width; ++widthIndex) {
+        const std::size_t finalWidthIndex = widthIndex * Height;
+
+        for (std::size_t heightIndex = 0; heightIndex < Height; ++heightIndex) {
+            const std::size_t finalIndex = finalWidthIndex + heightIndex;
+
+            if (!Fl::FloatMath::AreNearlyEqual(m_Base[finalIndex], m_Comparison[finalIndex], m_AbsoluteTolerance)) {
+                stream << "\n\tAt [" << widthIndex << "][" << heightIndex << "]: " << m_Base[finalIndex]
+                << " is not nearly equal to " << m_Comparison[finalIndex];
+            }
+        }
+    }
+
+    return stream.str();
+}
+
+template <typename T, typename ToleranceType>
+constexpr IsNearlyEqualToQuaternion<T, ToleranceType>::IsNearlyEqualToQuaternion(const Fl::Quaternion<T>& comparison,
+                                                                                 ToleranceType absoluteTolerance)
+    : m_Comparison{comparison}, m_AbsoluteTolerance{absoluteTolerance} {
+}
+
+template <typename T, typename ToleranceType>
+constexpr bool IsNearlyEqualToQuaternion<T, ToleranceType>::match(const Fl::Quaternion<T>& base) const {
+    const_cast<IsNearlyEqualToQuaternion*>(this)->m_Base = base;
+
+    return Fl::FloatMath::AreNearlyEqual(m_Base, m_Comparison, m_AbsoluteTolerance);
+}
+
+template <typename T, typename ToleranceType>
+std::string IsNearlyEqualToQuaternion<T, ToleranceType>::describe() const {
+    std::ostringstream stream;
+    stream.precision(std::numeric_limits<T>::digits10 + 3);
+
+    if (!Fl::FloatMath::AreNearlyEqual(m_Base.W(), m_Comparison.W(), m_AbsoluteTolerance)) {
+        stream << "\n\tOn w: " << m_Base.W() << " is not nearly equal to " << m_Comparison.W();
+    }
+
+    if (!Fl::FloatMath::AreNearlyEqual(m_Base.X(), m_Comparison.X(), m_AbsoluteTolerance)) {
+        stream << "\n\tOn x: " << m_Base.X() << " is not nearly equal to " << m_Comparison.X();
+    }
+
+    if (!Fl::FloatMath::AreNearlyEqual(m_Base.Y(), m_Comparison.Y(), m_AbsoluteTolerance)) {
+        stream << "\n\tOn y: " << m_Base.Y() << " is not nearly equal to " << m_Comparison.Y();
+    }
+
+    if (!Fl::FloatMath::AreNearlyEqual(m_Base.Z(), m_Comparison.Z(), m_AbsoluteTolerance)) {
+        stream << "\n\tOn z: " << m_Base.Z() << " is not nearly equal to " << m_Comparison.Z();
+    }
+
+    return stream.str();
+}

--- a/tests/Include/FlTests/CustomMatchers.inl
+++ b/tests/Include/FlTests/CustomMatchers.inl
@@ -30,7 +30,7 @@ constexpr IsNearlyEqualToVector<T, Size, ToleranceType>::IsNearlyEqualToVector(c
 }
 
 template <typename T, Fl::U64 Size, typename ToleranceType>
-constexpr bool IsNearlyEqualToVector<T, Size, ToleranceType>::match(const T& base) const {
+constexpr bool IsNearlyEqualToVector<T, Size, ToleranceType>::match(const Fl::Vector<T, Size>& base) const {
     const_cast<IsNearlyEqualToVector*>(this)->m_Base = base;
 
     return Fl::FloatMath::AreNearlyEqual(m_Base, m_Comparison, m_AbsoluteTolerance);

--- a/tests/Source/Math/Angle.cpp
+++ b/tests/Source/Math/Angle.cpp
@@ -1,0 +1,122 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#include <FlashlightEngine/Math/Angle.hpp>
+
+#include <FlTests/CustomMatchers.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Angle: Degrees to Radians", "[Math]") {
+    constexpr Fl::Degreesf deg45(45.f);
+    constexpr Fl::Degreesf deg90(90.f);
+    constexpr Fl::Degreesf deg180(180.f);
+    constexpr Fl::Degreesf deg360(360.f);
+
+    CHECK_THAT(Fl::Radiansf(deg45).Value, IsNearlyEqualTo(Fl::Constants::Pi<float> / 4));
+    CHECK_THAT(Fl::Radiansf(deg90).Value, IsNearlyEqualTo(Fl::Constants::Pi<float> / 2));
+    CHECK_THAT(Fl::Radiansf(deg180).Value, IsNearlyEqualTo(Fl::Constants::Pi<float>));
+    CHECK_THAT(Fl::Radiansf(deg360).Value, IsNearlyEqualTo(Fl::Constants::Pi<float> * 2));
+}
+
+TEST_CASE("Angle: Radians to Degrees", "[Math]") {
+    constexpr Fl::Radiansf radFourthPi(Fl::Constants::Pi<float> / 4);
+    constexpr Fl::Radiansf radHalfPi(Fl::Constants::Pi<float> / 2);
+    constexpr Fl::Radiansf radPi(Fl::Constants::Pi<float>);
+    constexpr Fl::Radiansf radTwoPi(Fl::Constants::Pi<float> * 2);
+
+    CHECK_THAT(Fl::Degreesf(radFourthPi).Value, IsNearlyEqualTo(45.f));
+    CHECK_THAT(Fl::Degreesf(radHalfPi).Value, IsNearlyEqualTo(90.f));
+    CHECK_THAT(Fl::Degreesf(radPi).Value, IsNearlyEqualTo(180.f));
+    CHECK_THAT(Fl::Degreesf(radTwoPi).Value, IsNearlyEqualTo(360.f));
+}
+
+TEST_CASE("Angle: Operations", "[Math]") {
+    // Literal operators
+    using namespace Fl::Literals;
+
+    constexpr auto degTest = 180.0_deg;
+    CHECK(std::is_same_v<Fl::Degreesld, std::decay_t<decltype(degTest)>>);
+
+    constexpr auto radTest = 3.14159265358979323846_rad;
+    CHECK(std::is_same_v<Fl::Radiansld, std::decay_t<decltype(radTest)>>);
+
+    // Type conversion operators
+    // To check conversion, verifying that values are (nearly) the same before & after conversion; in this example,
+    // there won't be much difference
+    // Degrees' & Radians' (un)equality operators automatically verify near-equality
+    constexpr Fl::Degreesf degFloat = degTest;
+    CHECK(degFloat == degTest);
+    constexpr Fl::Degreesd degDouble = degTest;
+    CHECK(degDouble == degTest);
+
+    constexpr Fl::Radiansf radFloat = radTest;
+    CHECK(radFloat == radTest);
+    constexpr Fl::Radiansd radDouble = radTest;
+    CHECK(radDouble == radTest);
+
+    // Checking that conversion between degrees & radians with different data types works as expected
+    constexpr Fl::Degreesf radToDegFloat = radTest;
+    CHECK_THAT(radToDegFloat.Value, IsNearlyEqualTo(180.0f));
+
+    constexpr Fl::Radiansf degToRadFloat = degTest;
+    CHECK_THAT(degToRadFloat.Value, IsNearlyEqualTo(Fl::Constants::Pi<float>));
+
+    // Mathematical operators
+    // Degrees
+    auto degAdd = degTest + 2.f;
+    // Checking that mathematical operations keeps the original angle type (no implicit cast to the value type)
+    CHECK(std::is_same_v<std::decay_t<decltype(degTest)>, std::decay_t<decltype(degAdd)>>);
+    CHECK_THAT(degAdd.Value, IsNearlyEqualTo(182.0L));
+
+    auto degSub = degTest - 2.f;
+    CHECK(std::is_same_v<std::decay_t<decltype(degTest)>, std::decay_t<decltype(degSub)>>);
+    CHECK_THAT(degSub.Value, IsNearlyEqualTo(178.0L));
+
+    auto degMul = degTest * 2.f;
+    CHECK(std::is_same_v<std::decay_t<decltype(degTest)>, std::decay_t<decltype(degMul)>>);
+    CHECK_THAT(degMul.Value, IsNearlyEqualTo(360.0L));
+
+    auto degDiv = degTest / 2.f;
+    CHECK(std::is_same_v<std::decay_t<decltype(degTest)>, std::decay_t<decltype(degDiv)>>);
+    CHECK_THAT(degDiv.Value, IsNearlyEqualTo(90.0L));
+
+    degAdd -= 2.f;
+    CHECK(degAdd == degTest);
+    degSub += 2.f;
+    CHECK(degSub == degTest);
+    degMul /= 2.f;
+    CHECK(degMul == degTest);
+    degDiv *= 2.f;
+    CHECK(degDiv == degTest);
+
+    // Radians
+    auto radAdd = radTest + Fl::Constants::Pi<float>;
+    // Checking that mathematical operations keeps the original angle type (no implicit cast to the value type)
+    CHECK(std::is_same_v<std::decay_t<decltype(radTest)>, std::decay_t<decltype(radAdd)>>);
+    // A float epsilon must be specified for the test to pass
+    // long double's epsilon is too precise, so we need to compare with a value of the type we made an operation with
+    CHECK_THAT(radAdd.Value, IsNearlyEqualTo(Fl::Constants::Pi<long double> * 2, std::numeric_limits<float>::epsilon()));
+
+    auto radSub = radTest - Fl::Constants::Pi<float>;
+    CHECK(std::is_same_v<std::decay_t<decltype(radTest)>, std::decay_t<decltype(radSub)>>);
+    CHECK_THAT(radSub.Value, IsNearlyEqualTo(0.0L, std::numeric_limits<float>::epsilon()));
+
+    auto radMul = radTest * 2.f;
+    CHECK(std::is_same_v<std::decay_t<decltype(radTest)>, std::decay_t<decltype(radMul)>>);
+    CHECK_THAT(radMul.Value, IsNearlyEqualTo(Fl::Constants::Pi<long double> * 2, std::numeric_limits<float>::epsilon()));
+
+    auto radDiv = radTest / 2.f;
+    CHECK(std::is_same_v<std::decay_t<decltype(radTest)>, std::decay_t<decltype(radDiv)>>);
+    CHECK_THAT(radDiv.Value, IsNearlyEqualTo(Fl::Constants::Pi<long double> / 2, std::numeric_limits<float>::epsilon()));
+
+    radAdd -= Fl::Constants::Pi<float>;
+    CHECK(radAdd == radTest);
+    radSub += Fl::Constants::Pi<float>;
+    CHECK(radSub == radTest);
+    radMul /= 2.f;
+    CHECK(radMul == radTest);
+    radDiv *= 2.f;
+    CHECK(radDiv == radTest);
+}

--- a/tests/Source/Math/FloatMath.cpp
+++ b/tests/Source/Math/FloatMath.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#include <FlashlightEngine/Math/FloatMath.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("FloatMath: Near-equality test", "[Math]") {
+    constexpr float floatEpsilon = std::numeric_limits<float>::epsilon();
+    constexpr double doubleEpsilon = std::numeric_limits<double>::epsilon();
+    constexpr long double longDoubleEpsilon = std::numeric_limits<long double>::epsilon();
+
+    // An epsilon difference is considered nearly equal
+    CHECK(Fl::FloatMath::AreNearlyEqual(0.f, floatEpsilon));
+    CHECK(Fl::FloatMath::AreNearlyEqual(0.0, doubleEpsilon));
+    CHECK(Fl::FloatMath::AreNearlyEqual(0.0L, longDoubleEpsilon));
+
+    // A two-epsilon difference is however not considered nearly equal
+    CHECK_FALSE(Fl::FloatMath::AreNearlyEqual(0.f, floatEpsilon * 2.f));
+    CHECK_FALSE(Fl::FloatMath::AreNearlyEqual(0.0, doubleEpsilon * 2.0));
+    CHECK_FALSE(Fl::FloatMath::AreNearlyEqual(0.0L, longDoubleEpsilon * 2.0L));
+}

--- a/tests/Source/Math/Matrix.cpp
+++ b/tests/Source/Math/Matrix.cpp
@@ -1,0 +1,505 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+
+#include <FlashlightEngine/Math/Matrix.hpp>
+#include <FlashlightEngine/Math/Vector.hpp>
+
+#include <FlTests/CustomMatchers.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <unordered_map>
+
+namespace {
+
+	// Declaring matrices to be tested
+	constexpr Fl::Mat3f mat31(4.12f, 25.1f, 30.7842f,
+		                      3.04f, 5.f, -64.5f,
+		                      -1.f, -7.54f, 8.41f);
+	constexpr Fl::Mat3f mat32(47.4f, 10.001f, 15.12f,
+		8.01f, -98.1f, 97.f,
+		12.54f, 70.f, -54.05f);
+
+	constexpr Fl::Mat4f mat41(-3.2f, 53.032f, 832.451f, 74.2f,
+		                      10.01f, 3.15f, -91.41f, 187.46f,
+		                      -6.f, -7.78f, 90.f, 38.f,
+		                      123.f, -74.8f, 147.0001f, 748.6f);
+	constexpr Fl::Mat4f mat42(5.5f, 98.14f, -8.24f, 42.f,
+		                      15.84f, -145.f, 3.145f, 52.74f,
+		                      -8.12f, 38.24f, 62.f, 43.12f,
+		                      74.f, 15.7f, 43.64f, 28.8f);
+
+}
+
+TEST_CASE("Matrix: Resize", "[Math]") {
+	constexpr Fl::Mat3f truncatedMat(mat41);
+	constexpr Fl::Mat4f expandedMat(truncatedMat);
+
+	CHECK(truncatedMat == Fl::Mat3f(-3.2f, 53.032f, 832.451f,
+		                            10.01f, 3.15f, -91.41f,
+		                            -6.f, -7.78f, 90.f));
+	CHECK(expandedMat == Fl::Mat4f(-3.2f, 53.032f, 832.451f, 0.f,
+		                           10.01f, 3.15f, -91.41f, 0.f,
+		                           -6.f, -7.78f, 90.f, 0.f,
+		                           0.f, 0.f, 0.f, 1.f));
+
+	CHECK(Fl::Mat4f(mat31) == Fl::Mat4f(4.12f, 25.1f, 30.7842f, 0.f,
+		                                3.04f, 5.f, -64.5f, 0.f,
+		                                -1.f, -7.54f, 8.41f, 0.f,
+		                                0.f, 0.f, 0.f, 1.f));
+
+	CHECK(Fl::Mat4f(Fl::Mat3f(mat42)) == Fl::Mat4f(5.5f, 98.14f, -8.24f, 0.f,
+		                                           15.84f, -145.f, 3.145f, 0.f,
+		                                           -8.12f, 38.24f, 62.f, 0.f,
+		                                           0.f, 0.f, 0.f, 1.f));
+}
+
+TEST_CASE("Matrix: Creation from vectors", "[Math]") {
+	constexpr auto testMatRows = Fl::Matrix<float, 3, 4>::FromRows(Fl::Vec3f(1.f, 2.f, 3.f),
+		                                                          Fl::Vec3f(4.f, 5.f, 6.f),
+		                                                          Fl::Vec3f(7.f, 8.f, 9.f),
+		                                                          Fl::Vec3f(10.f, 11.f, 12.f));
+	constexpr auto testMatColumns = Fl::Matrix<float, 3, 4>::FromColumns(Fl::Vec4f(1.f, 4.f, 7.f, 10.f),
+		                                                                 Fl::Vec4f(2.f, 5.f, 8.f, 11.f),
+		                                                                 Fl::Vec4f(3.f, 6.f, 9.f, 12.f));
+	constexpr Fl::Matrix<float, 3, 4> testRes(1.f, 2.f, 3.f,
+		                                      4.f, 5.f, 6.f,
+		                                      7.f, 8.f, 9.f,
+		                                      10.f, 11.f, 12.f);
+	CHECK(testMatRows == testRes);
+	CHECK(testMatColumns == testRes);
+
+	constexpr auto testMat31 = Fl::Mat3f::FromRows(mat31.GetRow(0), mat31.GetRow(1), mat31.GetRow(2));
+	CHECK(testMat31 == mat31);
+
+	constexpr auto testMat41 = Fl::Mat4f::FromColumns(mat41.GetColumn(0), mat41.GetColumn(1), mat41.GetColumn(2), mat41.GetColumn(3));
+	CHECK(testMat41 == mat41);
+}
+
+TEST_CASE("Matrix: Elements fetching", "[Math]") {
+	{
+		constexpr Fl::Mat3i testMat(0, 3, 6,
+			                        1, 4, 7,
+			                        2, 5, 8);
+
+		CHECK(testMat[0] == 0);
+		CHECK(testMat[1] == 1);
+		CHECK(testMat[2] == 2);
+		CHECK(testMat[3] == 3);
+		CHECK(testMat[4] == 4);
+		CHECK(testMat[5] == 5);
+		CHECK(testMat[6] == 6);
+		CHECK(testMat[7] == 7);
+		CHECK(testMat[8] == 8);
+	}
+
+	{
+		constexpr Fl::Matrix<int, 3, 2> testMat(0, 1, 2,
+			                                    3, 4, 5);
+
+		CHECK(testMat[0] == 0);
+		CHECK(testMat[1] == 3);
+		CHECK(testMat[2] == 1);
+		CHECK(testMat[3] == 4);
+		CHECK(testMat[4] == 2);
+		CHECK(testMat[5] == 5);
+	}
+
+	{
+		constexpr Fl::Matrix<int, 3, 2> testMat(0, 2, 4,
+			                                    1, 3, 5);
+
+		CHECK(testMat[0] == 0);
+		CHECK(testMat[1] == 1);
+		CHECK(testMat[2] == 2);
+		CHECK(testMat[3] == 3);
+		CHECK(testMat[4] == 4);
+		CHECK(testMat[5] == 5);
+	}
+
+	{
+		constexpr Fl::Matrix<int, 2, 3> testMat(0, 3,
+			                                    1, 4,
+			                                    2, 5);
+
+		CHECK(testMat[0] == 0);
+		CHECK(testMat[1] == 1);
+		CHECK(testMat[2] == 2);
+		CHECK(testMat[3] == 3);
+		CHECK(testMat[4] == 4);
+		CHECK(testMat[5] == 5);
+	}
+
+	//                   height:
+	//      [ 0, 3, 6 ] <- 0
+	//      [ 1, 4, 7 ] <- 1
+	//      [ 2, 5, 8 ] <- 2
+	//        ^  ^  ^
+	// width: 0  1  2
+	CHECK(mat31.GetElement(1, 1) == mat31[4]);
+	CHECK(mat31.GetElement(2, 1) == mat31[7]);
+	CHECK(mat31.GetElement(2, 2) == mat31[8]);
+
+	//                         height:
+	//      [ 0, 4,  8, 12 ] <- 0
+	//      [ 1, 5,  9, 13 ] <- 1
+	//      [ 2, 6, 10, 14 ] <- 2
+	//      [ 3, 7, 11, 15 ] <- 3
+	//        ^  ^   ^   ^
+	// width: 0  1   2   3
+	CHECK(mat41.GetElement(0, 0) == mat41[0]);
+	CHECK(mat41.GetElement(1, 2) == mat41[6]);
+	CHECK(mat41.GetElement(3, 3) == mat41[15]);
+
+	CHECK(mat31.GetRow(0) == Fl::Vec3f(4.12f, 25.1f, 30.7842f));
+	CHECK(mat42.GetRow(2) == Fl::Vec4f(-8.12f, 38.24f, 62.f, 43.12f));
+
+	CHECK(mat32.GetColumn(2) == Fl::Vec3f(15.12f, 97.f, -54.05f));
+	CHECK(mat41.GetColumn(1) == Fl::Vec4f(53.032f, 3.15f, -7.78f, -74.8f));
+
+	constexpr Fl::Matrix<float, 8, 2> testMat(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f,
+		                                      9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f);
+	CHECK(testMat[0] == 1.f);
+	CHECK(testMat[1] == 9.f);
+	CHECK(testMat[3] == 10.f);
+	CHECK(testMat[7] == 12.f);
+	CHECK(testMat[8] == 5.f);
+
+	CHECK(testMat.GetElement(0, 0) == 1.f);
+	CHECK(testMat.GetElement(0, 1) == 9.f);
+	CHECK(testMat.GetElement(1, 1) == 10.f);
+	CHECK(testMat.GetElement(3, 1) == 12.f);
+	CHECK(testMat.GetElement(4, 0) == 5.f);
+
+	CHECK(testMat.GetRow(1) == Fl::Vector<float, 8>(9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f));
+	CHECK(testMat.GetColumn(5) == Fl::Vec2f(6.f, 14.f));
+
+	constexpr Fl::Matrix<float, 2, 8> testMatTrans = testMat.Transpose();
+
+	CHECK(testMatTrans.GetRow(7) == Fl::Vec2f(8.f, 16.f));
+	CHECK(testMatTrans.GetColumn(0) == Fl::Vector<float, 8>(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f));
+}
+
+TEST_CASE("Matrix: Transposition", "[Math]") {
+	CHECK(mat31.Transpose() == Fl::Mat3f(4.12f, 3.04f, -1.f,
+		                                 25.1f, 5.f, -7.54f,
+		                                 30.7842f, -64.5f, 8.41f));
+
+	CHECK(mat41.Transpose() == Fl::Mat4f(-3.2f, 10.01f, -6.f, 123.f,
+		                                 53.032f, 3.15f, -7.78f, -74.8f,
+		                                 832.451f, -91.41f, 90.f, 147.000107f,
+		                                 74.2f, 187.46f, 38.f, 748.6f));
+
+
+	constexpr Fl::Matrix<float, 2, 3> mat2x3(1.f, 2.f,
+		                                     3.f, 4.f,
+		                                     5.f, 6.f);
+
+	constexpr Fl::Matrix<float, 3, 2> mat3x2(1.f, 3.f, 5.f,
+		                                     2.f, 4.f, 6.f);
+
+	CHECK(mat2x3.Transpose() == mat3x2);
+	CHECK(mat3x2.Transpose() == mat2x3);
+}
+
+TEST_CASE("Matrix: Inversion", "[Math]") {
+	// Results taken from Wolfram Alpha: https://tinyurl.com/dve4wvbs
+	CHECK(Fl::FloatMath::AreNearlyEqual(mat31.ComputeDeterminant(), -1404.90235872f));
+	CHECK(mat31.Inverse() == Fl::Mat3f(0.3162355f, 0.315469503f, 1.26191771f,
+		                               -0.0277126748f, -0.0465751f, -0.255764395f,
+		                               0.0127564743f, -0.00424570311f, 0.0396497f));
+
+	// Results taken from Wolfram Alpha: https://tinyurl.com/2p8d7m24
+	CHECK(Fl::FloatMath::AreNearlyEqual(mat41.ComputeDeterminant(), 348493952.f));
+	CHECK(mat41.Inverse() == Fl::Mat4f(0.00278244f, -0.0177149f, -0.0550912f, 0.00695677f,
+									   0.00705852f, 0.0187818f, -0.0407667f, -0.00333349f,
+									   0.00075337f, -0.00172146f, 0.00197614f, 0.000256093f,
+									   0.000100176f, 0.00512538f, 0.0045904f, -0.000190586f));
+
+	CHECK(Fl::Mat3f::Identity().ComputeDeterminant() == 1.f);
+	CHECK(Fl::Mat3f::Identity().Inverse() == Fl::Mat3f::Identity());
+}
+
+TEST_CASE("Matrix: Scalar operations", "[Math]") {
+	CHECK(mat31 * 3.f == Fl::Mat3f(12.36f, 75.3f, 92.3526f,
+		                           9.12f, 15.f, -193.5f,
+		                           -3.f, -22.62f, 25.23f));
+	CHECK(mat31 * 4.152f == Fl::Mat3f(17.10624f, 104.2152f, 127.8159984f,
+		                              12.62208f, 20.76f, -267.804f,
+		                              -4.152f, -31.30608f, 34.91832f));
+
+	CHECK(mat41 * 7.5f == Fl::Mat4f(-24.f, 397.74f, 6243.3825f, 556.5f,
+		                            75.075f, 23.625f, -685.575f, 1405.95f,
+		                            -45.f, -58.35f, 675.f, 285.f,
+		                            922.5f, -561.f, 1102.50075f, 5614.5f));
+	CHECK(mat41 * 8.0002f == Fl::Mat4f(-25.60064f, 424.2666064f, 6659.7744902f, 593.61484f,
+		                               80.082002f, 25.20063f, -731.298282f, 1499.717492f,
+		                               -48.0012f, -62.241556f, 720.018f, 304.0076f,
+		                               984.0246f, -598.41496f, 1176.03020002f, 5988.94972f));
+	CHECK(mat41 * 0.f == Fl::Mat4f(0.f, 0.f, 0.f, 0.f,
+		                           0.f, 0.f, 0.f, 0.f,
+		                           0.f, 0.f, 0.f, 0.f,
+		                           0.f, 0.f, 0.f, 0.f));
+}
+
+TEST_CASE("Matrix: matrix operations", "[math]") {
+	CHECK(mat31 - mat31 == Fl::Mat3f(0.f, 0.f, 0.f,
+		                             0.f, 0.f, 0.f,
+		                             0.f, 0.f, 0.f));
+
+	// Component-wise multiplication
+	CHECK(mat31 % mat32 == Fl::Mat3f(195.288f, 251.0251f, 465.457104f,
+		                             24.3504f, -490.5f, -6256.5f,
+		                             -12.54f, -527.8f, -454.5605f));
+
+	// Matrix multiplication
+
+	constexpr Fl::Mat3f res3132(782.372868f, -266.21188f, 833.10839f,
+		                        -624.684f, -4975.09696f, 4017.1898f,
+		                        -2.334007f, 1318.373f, -1201.0605f);
+	constexpr Fl::Mat3f res3231(210.57104f, 1125.7402f, 941.26578f,
+		                        -362.2228f, -1020.829f, 7389.801442f,
+		                        318.5148f, 1072.291f, -4583.526632f);
+
+	CHECK(mat31 * mat32 == res3132);
+	CHECK(mat32 * mat31 == res3231);
+
+	CHECK(mat31 * Fl::Mat3f::Identity() == mat31);
+	CHECK(mat41 * Fl::Mat4f::Identity() == mat41);
+
+	constexpr Fl::Matrix<float, 2, 3> mat2x3(1.f, 2.f,
+		                                     3.f, 4.f,
+		                                     5.f, 6.f);
+
+	constexpr Fl::Matrix<float, 3, 2> mat3x2(1.f, 2.f, 3.f,
+		                                     4.f, 5.f, 6.f);
+
+	// Results taken from Wolfram Alpha: https://tinyurl.com/3cx3zp94
+	CHECK(mat2x3 * mat3x2 == Fl::Mat3f(9.f, 12.f, 15.f,
+		                               19.f, 26.f, 33.f,
+		                               29.f, 40.f, 51.f));
+
+	// Results taken from Wolfram Alpha: https://tinyurl.com/y2chjdu2
+	CHECK(mat3x2 * mat2x3 == Fl::Mat2f(22.f, 28.f,
+		                               49.f, 64.f));
+}
+
+TEST_CASE("Matrix: Vector multiplication", "[Math]") {
+	const Fl::Mat3f matRotX(1.f, 0.f, 0.f,
+		                    0.f, 0.70710677f, -0.70710677f,
+		                    0.f, 0.70710677f, 0.70710677f);
+	CHECK(matRotX * Fl::Axis::X == Fl::Axis::X);
+	CHECK(Fl::Axis::X * matRotX == Fl::Axis::X);
+
+	const Fl::Mat3f matRotY(0.70710677f, 0.f, 0.70710677f,
+		                    0.f, 1.f, 0.f,
+		                    -0.70710677f, 0.f, 0.70710677f);
+	CHECK(matRotY * Fl::Axis::X == Fl::Vec3f(0.70710677f, 0.f, -0.70710677f));
+	CHECK(Fl::Axis::X * matRotY == Fl::Vec3f(0.70710677f, 0.f, 0.70710677f));
+
+	const Fl::Mat3f matRotZ(0.70710677f, -0.70710677f, 0.f,
+		                    0.70710677f, 0.70710677f, 0.f,
+		                    0.f, 0.f, 1.f);
+	CHECK(matRotZ * Fl::Axis::X == Fl::Vec3f(0.70710677f, 0.70710677f, 0.f));
+	CHECK(Fl::Axis::X * matRotZ == Fl::Vec3f(0.70710677f, -0.70710677f, 0.f));
+
+	// See: https://www.geogebra.org/m/je2vyv75
+	const Fl::Vec3f vec3(3.18f, 4.2f, 0.874f);
+
+	CHECK(matRotX * vec3 == Fl::Vec3f(vec3.X(), 2.35183716f, 3.58785963f));
+	CHECK(vec3 * matRotX == Fl::Vec3f(vec3.X(), 3.58785963f, -2.35183716f));
+
+	CHECK(matRotY * vec3 == Fl::Vec3f(2.86661077f, vec3.Y(), -1.63058829f));
+	CHECK(vec3 * matRotY == Fl::Vec3f(1.63058829f, vec3.Y(), 2.86661077f));
+
+	CHECK(matRotZ * vec3 == Fl::Vec3f(-0.721249f, 5.21844769f, vec3.Z()));
+	CHECK(vec3 * matRotZ == Fl::Vec3f(5.21844769f, 0.721249f, vec3.Z()));
+
+	CHECK(mat31 * vec3 == Fl::Vec3f(145.427f, -25.7058f, -27.4976597f));
+	CHECK(vec3 * mat31 == Fl::Vec3f(24.9956f, 94.2280426f, -165.655884f));
+	CHECK(mat32 * vec3 == Fl::Vec3f(205.95108f, -301.770203f, 286.637512f));
+	CHECK(vec3 * mat32 == Fl::Vec3f(195.333969f, -319.036804f, 408.241882f));
+
+	CHECK(Fl::Mat3f::Identity() * vec3 == vec3);
+	CHECK(vec3 * Fl::Mat3f::Identity() == vec3);
+
+	constexpr Fl::Vec2f vec2(10.f, 0.1f);
+
+	constexpr Fl::Matrix<float, 3, 2> mat3x2(1.f, 2.f, 3.f,
+		                                     4.f, 5.f, 6.f);
+
+	constexpr Fl::Matrix<float, 2, 3> mat2x3(1.f, 2.f,
+		                                     3.f, 4.f,
+		                                     5.f, 6.f);
+
+	// Results taken from Wolfram Alpha
+	CHECK(mat3x2 * vec3 == Fl::Vec2f(14.202f, 38.964f)); // https://tinyurl.com/2m6jx2he
+	CHECK(vec2 * mat3x2 == Fl::Vec3f(10.4f, 20.5f, 30.6f)); // https://tinyurl.com/43a9uufn
+
+	CHECK(vec3 * mat2x3 == Fl::Vec2f(20.15f, 28.404f)); // https://tinyurl.com/4m9teh6a
+	CHECK(mat2x3 * vec2 == Fl::Vec3f(10.2f, 30.4f, 50.6f)); // https://tinyurl.com/2p85wpk6
+
+	const Fl::Vec4f vec4(84.47f, 2.f, 0.001f, 847.12f);
+
+	CHECK(mat41 * vec4 == Fl::Vec4f(62692.896451f, 159652.86849f, 31668.27f, 644394.3890001f));
+	CHECK(vec4 * mat41 == Fl::Vec4f(103945.469f, -58878.6719f, 194661.125f, 640796.625f));
+
+	CHECK(mat42 * vec4 == Fl::Vec4f(36239.89676f, 45725.116745f, 35918.46f, 30679.27964f));
+	CHECK(vec4 * mat42 == Fl::Vec4f(63183.1367f, 21299.707f, 36278.6367f, 28050.3184f));
+
+	CHECK(Fl::Mat4f::Identity() * vec4 == vec4);
+	CHECK(vec4 * Fl::Mat4f::Identity() == vec4);
+
+	constexpr Fl::Matrix<float, 4, 2> mat4x2(1.f, 2.f, 3.f, 4.f,
+		                                     5.f, 6.f, 7.f, 8.f);
+
+	constexpr Fl::Matrix<float, 2, 4> mat2x4(1.f, 2.f,
+		                                     3.f, 4.f,
+		                                     5.f, 6.f,
+		                                     7.f, 8.f);
+
+	// Results taken from Wolfram Alpha
+	CHECK(mat4x2 * vec4 == Fl::Vec2f(3476.95288f, 7211.31689f)); // https://tinyurl.com/2xp73arw
+	CHECK(vec2 * mat4x2 == Fl::Vec4f(10.5f, 20.6f, 30.7f, 40.8f)); // https://tinyurl.com/5n73nzmk
+
+	CHECK(vec4 * mat2x4 == Fl::Vec2f(6020.31494f, 6953.90576f)); // https://tinyurl.com/26muhrx3
+	CHECK(mat2x4 * vec2 == Fl::Vec4f(10.2f, 30.4f, 50.6f, 70.8f)); // https://tinyurl.com/3k5p9uyk
+}
+
+TEST_CASE("Matrix: Hash", "[Math]") {
+	CHECK(mat31.Hash() == mat31.Hash());
+	CHECK_FALSE(mat31.Hash() == mat32.Hash());
+
+	CHECK(mat41.Hash() == mat41.Hash());
+	CHECK_FALSE(mat41.Hash() == mat42.Hash());
+
+	constexpr auto mat31Swizzled = Fl::Mat3f::FromRows(mat31.GetRow(2), mat31.GetRow(0), mat31.GetRow(1));
+	CHECK_FALSE(mat31.Hash() == mat31Swizzled.Hash());
+
+	constexpr Fl::Mat3f mat31Epsilon = mat31 + std::numeric_limits<float>::epsilon();
+	CHECK_FALSE(mat31.Hash() == mat31Epsilon.Hash());
+
+	// Checking that it behaves as expected when used in a hashmap
+	std::unordered_map<Fl::Mat3f, int> map;
+	map.try_emplace(mat31, 1);
+	map.try_emplace(mat31Swizzled, 2);
+	map.try_emplace(mat31Epsilon, 3);
+	map.try_emplace(mat32, 4);
+
+	CHECK(map.size() == 4);
+
+	CHECK(map.find(mat31)->second == 1);
+	CHECK(map.find(mat31Swizzled)->second == 2);
+	CHECK(map.find(mat31Epsilon)->second == 3);
+	CHECK(map.find(mat32)->second == 4);
+
+	map.erase(mat31Epsilon);
+	CHECK(map.find(mat31Epsilon) == map.cend());
+}
+
+TEST_CASE("Matrix: Near-equality", "[Math]") {
+	CHECK_FALSE(mat31 == mat32);
+
+	const Fl::Mat2f baseMat = Fl::Mat2f::Identity();
+	Fl::Mat2f compMat = baseMat;
+
+	CHECK(baseMat[0] == compMat[0]); // Copied, strict equality
+	CHECK(baseMat[1] == compMat[1]);
+	CHECK(baseMat[2] == compMat[2]);
+	CHECK(baseMat[3] == compMat[3]);
+
+	compMat += 0.0000001f; // Adding a tiny offset
+
+	CHECK_FALSE(baseMat[0] == compMat[0]); // Values not strictly equal
+	CHECK_FALSE(baseMat[1] == compMat[1]);
+	CHECK_FALSE(baseMat[2] == compMat[2]);
+	CHECK_FALSE(baseMat[3] == compMat[3]);
+
+	CHECK_THAT(baseMat[0], IsNearlyEqualTo(compMat[0])); // Near-equality components check
+	CHECK_THAT(baseMat[1], IsNearlyEqualTo(compMat[1]));
+	CHECK_THAT(baseMat[2], IsNearlyEqualTo(compMat[2]));
+	CHECK_THAT(baseMat[3], IsNearlyEqualTo(compMat[3]));
+
+	CHECK_THAT(baseMat, IsNearlyEqualToMatrix(compMat)); // Simpler check in a single call
+
+	CHECK(baseMat == compMat); // Matrix::operator== does a near-equality check on floating point types
+}
+
+TEST_CASE("Matrix: Strict equality", "[Math]") {
+	CHECK(mat31.StrictlyEquals(mat31));
+	CHECK(mat41.StrictlyEquals(mat41));
+
+	CHECK(std::equal_to<Fl::Mat3f>()(mat31, mat31));
+	CHECK(std::equal_to<Fl::Mat4f>()(mat41, mat41));
+
+	constexpr auto mat31Swizzled = Fl::Mat3f::FromRows(mat31.GetRow(2), mat31.GetRow(0), mat31.GetRow(1));
+	CHECK_FALSE(mat31.StrictlyEquals(mat31Swizzled));
+	CHECK_FALSE(std::equal_to<Fl::Mat3f>()(mat31, mat31Swizzled));
+
+	constexpr Fl::Mat3f mat31Epsilon = mat31 + std::numeric_limits<float>::epsilon();
+	CHECK(mat31 == mat31Epsilon); // Near-equality check
+	CHECK_FALSE(mat31.StrictlyEquals(mat31Epsilon)); // Strict-equality checks
+	CHECK_FALSE(std::equal_to<Fl::Mat3f>()(mat31, mat31Epsilon));
+
+	constexpr std::array<Fl::Mat3f, 3> matrices = { mat31Swizzled, mat31Epsilon, mat31 };
+
+	// When using a simple find(), which uses operator==, mat31Epsilon is found instead of mat31
+	const auto foundIter = std::find(matrices.cbegin(), matrices.cend(), mat31);
+	CHECK_FALSE(std::distance(matrices.cbegin(), foundIter) == 2);
+
+	// To search for a specific element, find_if() must be used with a strict equality check
+	const auto foundIfIter = std::find_if(matrices.cbegin(), matrices.cend(), [&](const Fl::Mat3f& compMat) { return mat31.StrictlyEquals(compMat); });
+	CHECK(std::distance(matrices.cbegin(), foundIfIter) == 2);
+
+	constexpr std::array<Fl::Mat3f, 3> swappedMatrices = { mat31Swizzled, mat31, mat31Epsilon };
+
+	// Trying to compare for equality fails with a simple std::equal on the matrices
+	CHECK(std::equal(matrices.cbegin(), matrices.cend(), swappedMatrices.cbegin()));
+
+	// When using the std::equal_to specialization, matrices are properly found to be unequal to each other
+	CHECK_FALSE(std::equal(matrices.cbegin(), matrices.cend(), swappedMatrices.cbegin(), std::equal_to<Fl::Mat3f>()));
+}
+
+TEST_CASE("Matrix: Less-than", "[Math]") {
+	CHECK(std::less<Fl::Mat3f>()(mat31, mat32));
+	CHECK_FALSE(std::less<Fl::Mat3f>()(mat32, mat31));
+	CHECK_FALSE(std::less<Fl::Mat3f>()(mat31, mat31)); // Equal matrices are not strictly less than the other
+	CHECK(std::less<Fl::Mat3f>()(mat31, mat31 + std::numeric_limits<float>::epsilon()));
+	CHECK_FALSE(std::less<Fl::Mat3f>()(mat31 + std::numeric_limits<float>::epsilon(), mat31)); // Performs a strict check, no tolerance allowed
+
+	CHECK(std::less<Fl::Mat4f>()(mat41, mat42));
+	CHECK_FALSE(std::less<Fl::Mat4f>()(mat42, mat41));
+	CHECK_FALSE(std::less<Fl::Mat4f>()(mat41, mat41));
+	CHECK(std::less<Fl::Mat4f>()(mat41, mat41 + std::numeric_limits<float>::epsilon()));
+	CHECK_FALSE(std::less<Fl::Mat4f>()(mat41 + std::numeric_limits<float>::epsilon(), mat41));
+}
+
+TEST_CASE("Matrix: Printing", "[Math]") {
+	std::stringstream stream;
+
+	stream << mat31;
+	CHECK(stream.str() == "[[ 4.12, 25.1, 30.7842 ]\n"
+		                  " [ 3.04, 5, -64.5 ]\n"
+		                  " [ -1, -7.54, 8.41 ]]");
+
+	stream.str(std::string()); // Resetting the stream
+	stream << mat32;
+	CHECK(stream.str() == "[[ 47.4, 10.001, 15.12 ]\n"
+		                  " [ 8.01, -98.1, 97 ]\n"
+		                  " [ 12.54, 70, -54.05 ]]");
+
+	stream.str(std::string());
+	stream << mat41;
+	CHECK(stream.str() == "[[ -3.2, 53.032, 832.451, 74.2 ]\n"
+		                  " [ 10.01, 3.15, -91.41, 187.46 ]\n"
+		                  " [ -6, -7.78, 90, 38 ]\n"
+		                  " [ 123, -74.8, 147, 748.6 ]]");
+
+	stream.str(std::string());
+	stream << Fl::Matrix<float, 3, 2>(1.f, 2.f, 3.f,
+		                              4.f, 5.f, 6.f);
+	CHECK(stream.str() == "[[ 1, 2, 3 ]\n"
+		                  " [ 4, 5, 6 ]]");
+}

--- a/tests/Source/Math/Quaternion.cpp
+++ b/tests/Source/Math/Quaternion.cpp
@@ -1,0 +1,310 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#include <FlashlightEngine/Math/Angle.hpp>
+#include <FlashlightEngine/Math/Matrix.hpp>
+#include <FlashlightEngine/Math/Quaternion.hpp>
+
+#include <FlTests/CustomMatchers.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace Fl::Literals;
+
+namespace {
+
+	const Fl::Quaternionf quat1(10_deg, Fl::Axis::X);
+	const Fl::Quaternionf quat2(90_deg, 1.f, -2.f, 5.f);
+	const Fl::Quaternionf quat3(180_deg, 1.f, -2.f, 5.f);
+
+} // namespace
+
+TEST_CASE("Quaternion: Deduction guides", "[Math]") {
+	const Fl::Quaternion quatfVal(1.f, 1.f, 1.f, 1.f);
+	const Fl::Quaternion quatfDeg(Fl::Degrees(0.f), Fl::Axis::X);
+	const Fl::Quaternion quatdRad(Fl::Radians(0.0), 1.0, 0.0, 0.0);
+
+	CHECK(std::is_same_v<std::decay_t<decltype(quatfVal)>, Fl::Quaternionf>);
+	CHECK(std::is_same_v<std::decay_t<decltype(quatfDeg)>, Fl::Quaternionf>);
+	CHECK(std::is_same_v<std::decay_t<decltype(quatdRad)>, Fl::Quaterniond>);
+}
+
+TEST_CASE("Quaternion: Dot product", "[Math]") {
+	const Fl::Quaternionf normedQuat1 = quat1.Normalize();
+	const Fl::Quaternionf normedQuat2 = quat2.Normalize();
+	const Fl::Quaternionf normedQuat3 = quat3.Normalize();
+
+	CHECK(quat1.Dot(quat1) == 1.f);
+	CHECK(normedQuat1.Dot(normedQuat1) == 1.f);
+
+	CHECK(quat2.Dot(quat2) == 15.5f);
+	CHECK_THAT(normedQuat2.Dot(normedQuat2), IsNearlyEqualTo(1.f));
+
+	CHECK(quat3.Dot(quat3) == 30.f);
+	CHECK_THAT(normedQuat3.Dot(normedQuat3), IsNearlyEqualTo(1.f));
+
+	CHECK_THAT(quat1.Dot(quat2), IsNearlyEqualTo(0.7660444f));
+	CHECK_THAT(normedQuat1.Dot(normedQuat2), IsNearlyEqualTo(0.1945755f));
+	CHECK(quat1.Dot(quat2) == quat2.Dot(quat1));
+
+	CHECK_THAT(quat3.Dot(quat1), IsNearlyEqualTo(0.0871557f));
+	CHECK_THAT(normedQuat3.Dot(normedQuat1), IsNearlyEqualTo(0.0159124f));
+	CHECK(quat3.Dot(quat1) == quat1.Dot(quat3));
+}
+
+TEST_CASE("Quaternion: Norm computation", "[Math]") {
+	CHECK_THAT(quat1.ComputeSquaredNorm(), IsNearlyEqualTo(1.f));
+	CHECK_THAT(quat1.ComputeNorm(), IsNearlyEqualTo(1.f));
+
+	CHECK_THAT(quat2.ComputeSquaredNorm(), IsNearlyEqualTo(15.5f));
+	CHECK_THAT(quat2.ComputeNorm(), IsNearlyEqualTo(3.93700385f));
+
+	CHECK_THAT(quat3.ComputeSquaredNorm(), IsNearlyEqualTo(30.f));
+	CHECK_THAT(quat3.ComputeNorm(), IsNearlyEqualTo(5.47722578f));
+}
+
+TEST_CASE("Quaternion: Interpolation", "[math]") {
+	// Results taken from Rust's nalgebra crate: https://play.rust-lang.org/?version=stable&mode=release&edition=2018&gist=fb93e96b13f3708b3b54aacef65365c2
+
+	CHECK(quat1.Lerp(quat2, 0.f) == quat1);
+	CHECK_THAT(quat1.Lerp(quat2, 0.25f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.92392272f, 0.2421435f, -0.35355338f, 0.88388348f)));
+	CHECK_THAT(quat1.Lerp(quat2, 0.5f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.85165071f, 0.39713126f, -0.70710677f, 1.767767f)));
+	CHECK_THAT(quat1.Lerp(quat2, 0.75f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.77937877f, 0.552119f, -1.06066f, 2.6516504f)));
+	CHECK(quat1.Lerp(quat2, 1.f) == quat2);
+
+	const Fl::Quaternionf normedQuat1 = quat1.Normalize();
+	const Fl::Quaternionf normedQuat2 = quat2.Normalize();
+
+	// Direct NLerp() (quaternions are not normalized beforehand)
+	CHECK(quat1.NLerp(quat2, 0.f) == normedQuat1);
+	CHECK_THAT(quat1.NLerp(quat2, 0.25f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.68513638f, 0.179562f, -0.262178f, 0.65544516f)));
+	CHECK_THAT(quat1.NLerp(quat2, 0.5f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.40111461f, 0.18704282f, -0.3330366f, 0.83259147f)));
+	CHECK_THAT(quat1.NLerp(quat2, 0.75f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.25880963f, 0.183343f, -0.3522152f, 0.880538f)));
+	CHECK(quat1.NLerp(quat2, 1.f) == normedQuat2);
+
+	// Pre-normalized NLerp() (almost strictly equivalent to NLerp(...).normalize() with non-normalized quaternions like above)
+	CHECK(normedQuat1.NLerp(normedQuat2, 0.f) == normedQuat1);
+	CHECK_THAT(normedQuat1.NLerp(normedQuat2, 0.25f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.94805622f, 0.13198756f, -0.10749099f, 0.26872748f)));
+	CHECK_THAT(normedQuat1.NLerp(normedQuat2, 0.5f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.76069689f, 0.17258403f, -0.23239529f, 0.58098823f)));
+	CHECK_THAT(normedQuat1.NLerp(normedQuat2, 0.75f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.45934007f, 0.18731718f, -0.32247299f, 0.8061825f)));
+	CHECK(normedQuat1.NLerp(normedQuat2, 1.f) == normedQuat2);
+
+	CHECK(normedQuat1.SLerp(normedQuat2, 0.f) == normedQuat1);
+	CHECK_THAT(normedQuat1.SLerp(normedQuat2, 0.25f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.93302816f, 0.13793936f, -0.12341759f, 0.30854398f)));
+	CHECK_THAT(normedQuat1.SLerp(normedQuat2, 0.5f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.76069695f, 0.17258403f, -0.23239529f, 0.58098823f)));
+	CHECK_THAT(normedQuat1.SLerp(normedQuat2, 0.75f), IsNearlyEqualToQuaternion(Fl::Quaternionf(0.49936396f, 0.18703631f, -0.31418267f, 0.78545672f)));
+	CHECK(normedQuat1.SLerp(normedQuat2, 1.f) == normedQuat2);
+}
+
+TEST_CASE("Quaternion: Matrix computation", "[Math]") {
+	const Fl::Mat4f quat1Mat = quat1.ComputeMatrix();
+	const Fl::Mat4f quat2Mat = quat2.ComputeMatrix();
+	const Fl::Mat4f quat3Mat = quat3.ComputeMatrix();
+
+	// Checking that quaternion multiplication is symmetrical to the matrices'
+	// The matrix multiplication may introduce a slight difference compared to the quaternion's
+	CHECK_THAT((quat1 * quat2).ComputeMatrix(), IsNearlyEqualToMatrix(quat1Mat * quat2Mat, std::numeric_limits<float>::epsilon() * 2));
+	CHECK_THAT((quat3 * quat1).ComputeMatrix(), IsNearlyEqualToMatrix(quat3Mat * quat1Mat));
+
+	CHECK_THAT(quat1.ComputeMatrix(), IsNearlyEqualToMatrix(Fl::Mat4f(1.f, 0.f, 0.f, 0.f,
+		                                                              0.f, 0.98480773f, -0.173648179f, 0.f,
+		                                                              0.f, 0.173648179f, 0.98480773f, 0.f,
+		                                                              0.f, 0.f, 0.f, 1.f)));
+
+	CHECK_THAT(quat2.ComputeMatrix(), IsNearlyEqualToMatrix(Fl::Mat4f(-0.870967627f, -0.45161289f, 0.193548396f, 0.f,
+		                                                              0.193548396f, -0.677419245f, -0.709677398f, 0.f,
+		                                                              0.45161289f, -0.580645144f, 0.677419424f, 0.f,
+		                                                              0.f, 0.f, 0.f, 1.f)));
+
+	CHECK_THAT(quat3.ComputeMatrix(), IsNearlyEqualToMatrix(Fl::Mat4f(-0.933333397f, -0.133333355f, 0.333333343f, 0.f,
+		                                                              -0.133333325f, -0.733333409f, -0.666666687f, 0.f,
+		                                                              0.333333343f, -0.666666687f, 0.666666627f, 0.f,
+		                                                              0.f, 0.f, 0.f, 1.f)));
+}
+
+TEST_CASE("Quaternion: Vector multiplication", "[Math]") {
+	// See: https://www.geogebra.org/m/aderzasm
+
+	const Fl::Quaternionf quatRotX(45_deg, Fl::Axis::X);
+	CHECK(quatRotX * Fl::Axis::X == Fl::Axis::X);
+	CHECK(Fl::Axis::X * quatRotX == Fl::Axis::X);
+
+	const Fl::Quaternionf quatRotY(45_deg, Fl::Axis::Y);
+	CHECK(quatRotY * Fl::Axis::X == Fl::Vec3f(0.70710677f, 0.f, -0.70710677f));
+	CHECK(Fl::Axis::X * quatRotY == Fl::Vec3f(0.70710677f, 0.f, 0.70710677f));
+
+	const Fl::Quaternionf quatRotZ(45_deg, Fl::Axis::Z);
+	CHECK(quatRotZ * Fl::Axis::X == Fl::Vec3f(0.70710677f, 0.70710677f, 0.f));
+	CHECK(Fl::Axis::X * quatRotZ == Fl::Vec3f(0.70710677f, -0.70710677f, 0.f));
+
+	CHECK(Fl::Axis::Z * Fl::Quaternionf(90_deg, Fl::Axis::Y) == -Fl::Axis::X);
+	CHECK(Fl::Axis::Z * Fl::Mat3f(Fl::Quaternionf(90_deg, Fl::Axis::Y).ComputeMatrix()) == -Fl::Axis::X);
+
+	constexpr Fl::Vec3f pos(0.123f, 14.51145f, 7.58413f);
+
+	CHECK(quatRotX * pos == Fl::Vec3f(pos.X(), 4.89835405f, 15.6239338f));
+	CHECK(quatRotY * pos == Fl::Vec3f(5.44976425f, pos.Y(), 5.27581501f));
+	CHECK(quatRotZ * pos == Fl::Vec3f(-10.1741714f, 10.3481178f, pos.Z()));
+
+	CHECK_THAT(pos * quatRotX, IsNearlyEqualToVector(Fl::Vec3f(pos.X(), 15.6239338f, -4.89835596f), 0.000001f));
+	CHECK_THAT(pos * quatRotY, IsNearlyEqualToVector(Fl::Vec3f(-5.27581596f, pos.Y(), 5.4497633f)));
+	CHECK_THAT(pos * quatRotZ, IsNearlyEqualToVector(Fl::Vec3f(10.3481188f, 10.1741686f, pos.Z())));
+
+	// Checking that the matrix multiplication behaves the same way
+
+	CHECK_THAT(quatRotX * pos, IsNearlyEqualToVector(Fl::Mat3f(quatRotX.ComputeMatrix()) * pos, 0.000001f));
+	CHECK_THAT(quatRotY * pos, IsNearlyEqualToVector(Fl::Mat3f(quatRotY.ComputeMatrix()) * pos, 0.000001f));
+	CHECK_THAT(quatRotZ * pos, IsNearlyEqualToVector(Fl::Mat3f(quatRotZ.ComputeMatrix()) * pos, 0.000001f));
+
+	CHECK_THAT(pos * quatRotX, IsNearlyEqualToVector(pos * Fl::Mat3f(quatRotX.ComputeMatrix()), 0.000001f));
+	CHECK_THAT(pos * quatRotY, IsNearlyEqualToVector(pos * Fl::Mat3f(quatRotY.ComputeMatrix()), 0.000001f));
+	CHECK_THAT(pos * quatRotZ, IsNearlyEqualToVector(pos * Fl::Mat3f(quatRotZ.ComputeMatrix()), 0.000001f));
+}
+
+TEST_CASE("Quaternion: Quaternion multiplication", "[Math]") {
+	constexpr Fl::Quaternionf unitQuat = Fl::Quaternionf::Identity();
+	constexpr Fl::Mat4f unitQuatMat = unitQuat.ComputeMatrix();
+	CHECK(unitQuatMat == Fl::Mat4f::Identity());
+
+	constexpr Fl::Quaternionf squareUnitQuat = unitQuat * unitQuat;
+	CHECK(squareUnitQuat.ComputeMatrix() == unitQuatMat);
+
+	const Fl::Quaternionf quatRotX(45.0_deg, Fl::Axis::X);
+	const Fl::Quaternionf multRotX = quatRotX * quatRotX.Conjugate();
+	CHECK(multRotX.ComputeMatrix() == unitQuatMat);
+
+	const Fl::Quaternionf quatRotY(45.0_deg, Fl::Axis::Y);
+	const Fl::Quaternionf multRotY = quatRotY * quatRotY.Conjugate();
+	CHECK(multRotY.ComputeMatrix() == unitQuatMat);
+
+	const Fl::Quaternionf quatRotZ(45.0_deg, Fl::Axis::Z);
+	const Fl::Quaternionf multRotZ = quatRotZ * quatRotZ.Conjugate();
+	CHECK(multRotZ.ComputeMatrix() == unitQuatMat);
+
+	const Fl::Quaternionf quat12 = quat1 * quat2;
+
+	// Results taken from Wolfram Alpha: https://tinyurl.com/rxavw82
+	CHECK(quat12.W() == 0.642787635f);
+	CHECK(quat12.X() == 0.766044438f);
+	CHECK(quat12.Y() == -1.716974139f);
+	CHECK(quat12.Z() == 3.398823261f);
+	CHECK_THAT(quat12.ComputeNorm(), IsNearlyEqualTo(3.9370039f));
+	CHECK_THAT(quat12.ComputeMatrix(), IsNearlyEqualToMatrix(Fl::Mat4f(-0.870968f, -0.451613f, 0.1935484f, 0.f,
+		                                                               0.1121862f, -0.5663f, -0.8165285f, 0.f,
+		                                                               0.4783612f, -0.6894565f, 0.5438936f, 0.f,
+		                                                               0.f, 0.f, 0.f, 1.f)));
+
+	const Fl::Quaternionf quat21 = quat2 * quat1;
+
+	// Results taken from Wolfram Alpha: https://tinyurl.com/426hupnb
+	CHECK(quat21.W() == 0.642787635f);
+	CHECK(quat21.X() == 0.766044438f);
+	CHECK(quat21.Y() == -1.10069f);
+	CHECK(quat21.Z() == 3.645337105f);
+	CHECK_THAT(quat21.ComputeNorm(), IsNearlyEqualTo(3.9370039f));
+	CHECK_THAT(quat21.ComputeMatrix(), IsNearlyEqualToMatrix(Fl::Mat4f(-0.870968f, -0.411142588f, 0.269029707f, 0.f,
+		                                                               0.193548396f, -0.790362f, -0.581263244f, 0.f,
+		                                                               0.451613f, -0.454191267f, 0.76795578f, 0.f,
+		                                                               0.f, 0.f, 0.f, 1.f)));
+}
+
+TEST_CASE("Quaternion: Structured bindings", "[math]") {
+	static_assert(std::tuple_size_v<decltype(quat1)> == 4);
+	static_assert(std::tuple_size_v<decltype(Fl::Quaterniond::Identity())> == 4);
+
+	static_assert(std::is_same_v<std::tuple_element_t<0, decltype(quat1)>, const float>);
+	static_assert(std::is_same_v<std::tuple_element_t<2, decltype(Fl::Quaterniond::Identity())>, double>);
+	static_assert(std::is_same_v<std::tuple_element_t<3, decltype(Fl::Quaternion<const double>::Identity())>, const double>);
+
+	// When using structured bindings, Fl::get<I>(e) is exclusively found using ADL (https://en.cppreference.com/w/cpp/language/adl)
+	CHECK(Fl::get<0>(quat1) == quat1.W());
+	CHECK(Fl::get<1>(quat1) == quat1.X());
+	CHECK(Fl::get<2>(quat1) == quat1.Y());
+	CHECK(Fl::get<3>(quat1) == quat1.Z());
+
+	{
+		const auto [w, x, y, z] = quat1;
+		static_assert(std::is_same_v<decltype(w), const float>);
+		static_assert(std::is_same_v<decltype(x), const float>);
+		static_assert(std::is_same_v<decltype(y), const float>);
+		static_assert(std::is_same_v<decltype(z), const float>);
+		// Only values are returned, never references
+		static_assert(std::is_same_v<decltype(Fl::get<0>(quat1)), float>);
+		static_assert(std::is_same_v<decltype(Fl::get<1>(quat1)), float>);
+		static_assert(std::is_same_v<decltype(Fl::get<2>(quat1)), float>);
+		static_assert(std::is_same_v<decltype(Fl::get<3>(quat1)), float>);
+
+		CHECK(w == quat1.W());
+		CHECK(x == quat1.X());
+		CHECK(y == quat1.Y());
+		CHECK(z == quat1.Z());
+	}
+
+	{
+		constexpr Fl::Quaterniond quatDouble(1.0, 2.0, 3.0, 4.0);
+		auto [w, x, y, z] = quatDouble;
+		static_assert(std::is_same_v<decltype(w), double>);
+		static_assert(std::is_same_v<decltype(x), double>);
+		static_assert(std::is_same_v<decltype(y), double>);
+		static_assert(std::is_same_v<decltype(z), double>);
+		// Only values are returned, never references
+		static_assert(std::is_same_v<decltype(Fl::get<0>(quatDouble)), double>);
+		static_assert(std::is_same_v<decltype(Fl::get<1>(quatDouble)), double>);
+		static_assert(std::is_same_v<decltype(Fl::get<2>(quatDouble)), double>);
+		static_assert(std::is_same_v<decltype(Fl::get<3>(quatDouble)), double>);
+
+		CHECK(w == quatDouble.W());
+		CHECK(x == quatDouble.X());
+		CHECK(y == quatDouble.Y());
+		CHECK(z == quatDouble.Z());
+	}
+
+	// Not checking structured bindings with reference types, as quaternions never return any
+}
+
+TEST_CASE("Quaternion: Near-equality", "[Math]") {
+	CHECK_FALSE(quat1 == quat2);
+
+	constexpr Fl::Quaternionf baseQuat(1.f, 1.f, 1.f, 1.f);
+	Fl::Quaternionf compQuat = baseQuat;
+
+	CHECK(baseQuat.W() == compQuat.W()); // Copied, strict equality
+	CHECK(baseQuat.X() == compQuat.X());
+	CHECK(baseQuat.Y() == compQuat.Y());
+	CHECK(baseQuat.Z() == compQuat.Z());
+
+	compQuat = Fl::Quaternionf(baseQuat.W() + 0.0000001f,
+		                        baseQuat.X() + 0.0000001f,
+		                        baseQuat.Y() + 0.0000001f,
+		                        baseQuat.Z() + 0.0000001f); // Adding a tiny offset
+
+	CHECK_FALSE(baseQuat.W() == compQuat.W()); // Values not strictly equal
+	CHECK_FALSE(baseQuat.X() == compQuat.X());
+	CHECK_FALSE(baseQuat.Y() == compQuat.Y());
+	CHECK_FALSE(baseQuat.Z() == compQuat.Z());
+
+	CHECK_THAT(baseQuat.W(), IsNearlyEqualTo(compQuat.W())); // Near-equality components check
+	CHECK_THAT(baseQuat.X(), IsNearlyEqualTo(compQuat.X()));
+	CHECK_THAT(baseQuat.Y(), IsNearlyEqualTo(compQuat.Y()));
+	CHECK_THAT(baseQuat.Z(), IsNearlyEqualTo(compQuat.Z()));
+
+	CHECK_THAT(baseQuat, IsNearlyEqualToQuaternion(compQuat)); // Simpler check in a single call
+
+	CHECK(baseQuat == compQuat); // Quaternion::operator== does a near-equality check
+}
+
+TEST_CASE("Quaternion: printing", "[Math]") {
+	std::stringstream stream;
+
+	stream << quat1;
+	CHECK(stream.str() == "[ 0.996195, 0.0871557, 0, 0 ]");
+
+	stream.str(std::string()); // Resetting the stream
+	stream << quat2;
+	CHECK(stream.str() == "[ 0.707107, 0.707107, -1.41421, 3.53553 ]");
+
+	stream.str(std::string());
+	stream << quat3;
+	CHECK(stream.str() == "[ -4.37114e-08, 1, -2, 5 ]");
+}

--- a/tests/Source/Math/Transform.cpp
+++ b/tests/Source/Math/Transform.cpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#include <FlashlightEngine/Math/Angle.hpp>
+#include <FlashlightEngine/Math/Matrix.hpp>
+#include <FlashlightEngine/Math/Transform.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace Fl::Literals;
+
+TEST_CASE("Transform: Position", "[Math]") {
+	Fl::Transform transform;
+	CHECK(transform.GetPosition() == Fl::Vec3f(0.f, 0.f, 0.f));
+	CHECK(transform.WasUpdated()); // By default, a transform always has an updated status
+	transform.SetUpdated(false);
+
+	transform.Translate(Fl::Vec3f(0.f, 0.f, 0.f));
+	transform.SetPosition(0.f, 0.f, 0.f); // Equivalent of the above
+	CHECK(transform.GetPosition() == Fl::Vec3f(0.f, 0.f, 0.f));
+	CHECK(transform.WasUpdated());
+
+	// Assigning a rotation for the following calls
+	transform.SetRotation(90_deg, Fl::Axis::Y);
+	transform.SetUpdated(false);
+
+	// Move() performs a relative displacement, taking rotation into account
+	transform.Move(Fl::Vec3f(0.f, 0.f, 1.f));
+	transform.Move(0.f, 0.f, 1.f); // Equivalent of the above
+	CHECK(transform.GetPosition() == Fl::Vec3f(2.f, 0.f, 0.f));
+	CHECK(transform.WasUpdated());
+	transform.SetUpdated(false);
+
+	const Fl::Mat4f translationMat = transform.ComputeTranslationMatrix(false);
+	CHECK(Fl::Mat3f(translationMat) == Fl::Mat3f::Identity());
+	CHECK(Fl::Vec3f(translationMat.GetColumn(3)) == transform.GetPosition());
+	CHECK_FALSE(transform.WasUpdated()); // Computing the translation matrix does not change the update state
+
+	const Fl::Mat4f reversedTranslationMat = transform.ComputeTranslationMatrix(true); // Reversing the translation
+	CHECK(Fl::Mat3f(reversedTranslationMat) == Fl::Mat3f::Identity());
+	CHECK(Fl::Vec3f(reversedTranslationMat.GetColumn(3)) == -transform.GetPosition());
+	CHECK_FALSE(transform.WasUpdated());
+}
+
+TEST_CASE("Transform: Rotation", "[Math]") {
+	Fl::Transform transform;
+	CHECK(transform.GetRotation() == Fl::Quaternionf::Identity());
+	CHECK(transform.WasUpdated()); // By default, a transform always has an updated status
+	transform.SetUpdated(false);
+
+	transform.SetRotation(Fl::Quaternionf(90_deg, Fl::Axis::Y));
+	transform.SetRotation(90_deg, Fl::Axis::Y); // Equivalent of the above
+	CHECK(transform.GetRotation() == Fl::Quaternionf(90_deg, Fl::Axis::Y));
+	CHECK(transform.WasUpdated()); // Changing the rotation does set the updated state
+	transform.SetUpdated(false);
+
+	transform.Rotate(Fl::Quaternionf(-45_deg, Fl::Axis::Y));
+	transform.Rotate(-45_deg, Fl::Axis::Y); // Equivalent of the above
+	CHECK(transform.GetRotation() == Fl::Quaternionf::Identity());
+	CHECK(transform.WasUpdated());
+	transform.SetUpdated(false);
+
+	// Rotating on multiple axes at the same time; the rotation around X will be applied before the one around Y
+	transform.Rotate(90_deg, 45_deg);
+	CHECK(transform.GetRotation() == Fl::Quaternionf(45_deg, Fl::Axis::Y) * Fl::Quaternionf(90_deg, Fl::Axis::X));
+	CHECK(transform.WasUpdated());
+	transform.SetUpdated(false);
+}
+
+TEST_CASE("Transform: Scale", "[math]") {
+	Fl::Transform transform;
+	CHECK(transform.GetScale() == Fl::Vec3f(1.f, 1.f, 1.f));
+	CHECK(transform.WasUpdated()); // By default, a transform always has an updated status
+	transform.SetUpdated(false);
+
+	transform.SetScale(2.f);
+	transform.SetScale(Fl::Vec3f(2.f, 2.f, 2.f)); // Equivalent of the above
+	transform.SetScale(2.f, 2.f, 2.f); // Equivalent of the above
+	CHECK(transform.GetScale() == Fl::Vec3f(2.f, 2.f, 2.f));
+	CHECK(transform.WasUpdated()); // Changing the scale does set the updated state
+	transform.SetUpdated(false);
+
+	// The scale is relative: 0.5 downscales the current value by half
+	transform.Scale(0.5f);
+	transform.Scale(Fl::Vec3f(0.5f, 0.5f, 0.5f)); // Equivalent of the above
+	transform.Scale(0.5f, 0.5f, 0.5f); // Equivalent of the above
+	CHECK(transform.GetScale() == Fl::Vec3f(0.25f, 0.25f, 0.25f));
+	CHECK(transform.WasUpdated());
+}
+
+TEST_CASE("Transform: Operations", "[Math]") {
+	Fl::Transform transform(Fl::Vec3f(1.f, 0.f, 1.f), Fl::Quaternionf(90_deg, Fl::Axis::Y), Fl::Vec3f(2.f));
+
+	CHECK(transform.GetPosition() == Fl::Vec3f(1.f, 0.f, 1.f));
+	CHECK(transform.GetRotation() == Fl::Quaternionf(90_deg, Fl::Axis::Y));
+	CHECK(transform.GetScale() == Fl::Vec3f(2.f, 2.f, 2.f));
+
+	transform.SetUpdated(false);
+	Fl::Mat4f transformMat = transform.ComputeTransformMatrix();
+	CHECK(Fl::Vec3f(transformMat.GetColumn(3)) == transform.GetPosition());
+	CHECK(transformMat == Fl::Mat4f(0.f, 0.f, 2.f, 1.f,
+		                            0.f, 2.f, 0.f, 0.f,
+		                           -2.f, 0.f, 0.f, 1.f,
+		                            0.f, 0.f, 0.f, 1.f));
+	CHECK_FALSE(transform.WasUpdated()); // Computing the transform matrix doesn't change the update state
+
+	transform.Rotate(45_deg, Fl::Axis::X);
+	transform.Move(0.f, 0.f, -1.f);
+	transform.SetScale(1.f);
+
+	transform.SetUpdated(false);
+	transformMat = transform.ComputeTransformMatrix();
+	CHECK(Fl::Vec3f(transformMat.GetColumn(3)) == transform.GetPosition());
+	CHECK(transformMat == Fl::Mat4f(-8.9407e-08f, 0.707106829f,  0.707106709f, 0.292893231f,
+		                             0.f,         0.707106769f, -0.707106829f, 0.707106769f,
+		                            -1.f,         0.f,          -1.19209e-07f, 1.f,
+		                             0.f,         0.f,           0.f,          1.f));
+	CHECK_FALSE(transform.WasUpdated());
+}

--- a/tests/Source/Math/Utils.cpp
+++ b/tests/Source/Math/Utils.cpp
@@ -1,0 +1,188 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#include <FlashlightEngine/Math/Utils.hpp>
+#include <FlashlightEngine/Math/Vector.hpp>
+
+#include <FlTests/CustomMatchers.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Utils: Lerp arithmetic types", "[Math]") {
+	CHECK(Fl::MathUtils::Lerp(0.f, 1.f, 0.f) == 0.f);
+	CHECK(Fl::MathUtils::Lerp(0.f, 1.f, 0.25f) == 0.25f);
+	CHECK(Fl::MathUtils::Lerp(0.f, 1.f, 0.5f) == 0.5f);
+	CHECK(Fl::MathUtils::Lerp(0.f, 1.f, 0.75f) == 0.75f);
+	CHECK(Fl::MathUtils::Lerp(0.f, 1.f, 1.f) == 1.f);
+
+	CHECK(Fl::MathUtils::Lerp(-5.f, 5.f, 0.f) == -5.f);
+	CHECK(Fl::MathUtils::Lerp(-5.f, 5.f, 0.25f) == -2.5f);
+	CHECK(Fl::MathUtils::Lerp(-5.f, 5.f, 0.5f) == 0.f);
+	CHECK(Fl::MathUtils::Lerp(-5.f, 5.f, 0.75f) == 2.5f);
+	CHECK(Fl::MathUtils::Lerp(-5.f, 5.f, 1.f) == 5.f);
+
+	CHECK(Fl::MathUtils::Lerp(-1.43f, 8.12f, 0.f) == -1.43f);
+	CHECK(Fl::MathUtils::Lerp(-1.43f, 8.12f, 0.25f) == 0.9575f);
+	CHECK(Fl::MathUtils::Lerp(-1.43f, 8.12f, 0.5f) == 3.345f);
+	CHECK(Fl::MathUtils::Lerp(-1.43f, 8.12f, 0.75f) == 5.7325001f);
+	CHECK(Fl::MathUtils::Lerp(-1.43f, 8.12f, 1.f) == 8.12f);
+
+	CHECK(Fl::MathUtils::Lerp(457, 5324, 0.f) == 457);
+	CHECK(Fl::MathUtils::Lerp(457, 5324, 0.25f) == 1673);
+	CHECK(Fl::MathUtils::Lerp(457, 5324, 0.5f) == 2890);
+	CHECK(Fl::MathUtils::Lerp(457, 5324, 0.75f) == 4107);
+	CHECK(Fl::MathUtils::Lerp(457, 5324, 1.f) == 5324);
+}
+
+TEST_CASE("MathUtils: Lerp vector", "[Math]") {
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(0.f), Fl::Vec3f(1.f), 0.f) == Fl::Vec3f(0.f));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(0.f), Fl::Vec3f(1.f), 0.25f) == Fl::Vec3f(0.25f));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(0.f), Fl::Vec3f(1.f), 0.5f) == Fl::Vec3f(0.5f));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(0.f), Fl::Vec3f(1.f), 0.75f) == Fl::Vec3f(0.75f));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(0.f), Fl::Vec3f(1.f), 1.f) == Fl::Vec3f(1.f));
+						 
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(1.f, 2.f, 3.f), Fl::Vec3f(3.f, 2.f, 1.f), 0.f) == Fl::Vec3f(1.f, 2.f, 3.f));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(1.f, 2.f, 3.f), Fl::Vec3f(3.f, 2.f, 1.f), 0.25f) == Fl::Vec3f(1.5f, 2.f, 2.5f));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(1.f, 2.f, 3.f), Fl::Vec3f(3.f, 2.f, 1.f), 0.5f) == Fl::Vec3f(2.f, 2.f, 2.f));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(1.f, 2.f, 3.f), Fl::Vec3f(3.f, 2.f, 1.f), 0.75f) == Fl::Vec3f(2.5f, 2.f, 1.5f));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3f(1.f, 2.f, 3.f), Fl::Vec3f(3.f, 2.f, 1.f), 1.f) == Fl::Vec3f(3.f, 2.f, 1.f));
+						 
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3i(140, 874, 3541), Fl::Vec3i(841, 53, 4712), 0.f) == Fl::Vec3i(140, 874, 3541));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3i(140, 874, 3541), Fl::Vec3i(841, 53, 4712), 0.25f) == Fl::Vec3i(315, 668, 3833));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3i(140, 874, 3541), Fl::Vec3i(841, 53, 4712), 0.5f) == Fl::Vec3i(490, 463, 4126));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3i(140, 874, 3541), Fl::Vec3i(841, 53, 4712), 0.75f) == Fl::Vec3i(665, 258, 4419));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3i(140, 874, 3541), Fl::Vec3i(841, 53, 4712), 1.f) == Fl::Vec3i(841, 53, 4712));
+						 
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3b(255, 140, 27), Fl::Vec3b(75, 241, 173), 0.f) == Fl::Vec3b(255, 140, 27));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3b(255, 140, 27), Fl::Vec3b(75, 241, 173), 0.25f) == Fl::Vec3b(210, 165, 63));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3b(255, 140, 27), Fl::Vec3b(75, 241, 173), 0.5f) == Fl::Vec3b(165, 190, 100));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3b(255, 140, 27), Fl::Vec3b(75, 241, 173), 0.75f) == Fl::Vec3b(120, 215, 136));
+	CHECK(Fl::MathUtils::Lerp(Fl::Vec3b(255, 140, 27), Fl::Vec3b(75, 241, 173), 1.f) == Fl::Vec3b(75, 241, 173));
+}
+
+TEST_CASE("MathUtils: Smoothstep value", "[Math]") {
+	CHECK(Fl::MathUtils::Smoothstep(0.f) == 0.f);
+	CHECK(Fl::MathUtils::Smoothstep(0.25f) == 0.15625f);
+	CHECK(Fl::MathUtils::Smoothstep(0.5f) == 0.5f);
+	CHECK(Fl::MathUtils::Smoothstep(0.75f) == 0.84375f);
+	CHECK(Fl::MathUtils::Smoothstep(1.f) == 1.f);
+}
+
+TEST_CASE("MathUtils: Smoothstep range", "[Math]") {
+	CHECK(Fl::MathUtils::Smoothstep(0.f, 1.f, -1.f) == 0.f); // If value < minThresh, returns 0
+	CHECK(Fl::MathUtils::Smoothstep(0.f, 1.f, 0.f) == 0.f);
+	CHECK(Fl::MathUtils::Smoothstep(0.f, 1.f, 0.25f) == 0.15625f);
+	CHECK(Fl::MathUtils::Smoothstep(0.f, 1.f, 0.5f) == 0.5f);
+	CHECK(Fl::MathUtils::Smoothstep(0.f, 1.f, 0.75f) == 0.84375f);
+	CHECK(Fl::MathUtils::Smoothstep(0.f, 1.f, 1.f) == 1.f);
+	CHECK(Fl::MathUtils::Smoothstep(0.f, 1.f, 2.f) == 1.f); // If value > maxThresh, returns 1
+
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, -10.f) == 0.f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, -5.f - std::numeric_limits<float>::epsilon()) == 0.f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, -5.f) == 0.f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, -4.5f) == 0.00725000072f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, -2.5f) == 0.15625f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, -0.5f) == 0.42524996f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, 0.f) == 0.5f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, 0.5f) == 0.57475001f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, 2.5f) == 0.84375f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, 4.5f) == 0.99274999f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, 5.f) == 1.f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, 5.f + std::numeric_limits<float>::epsilon()) == 1.f);
+	CHECK(Fl::MathUtils::Smoothstep(-5.f, 5.f, 10.f) == 1.f);
+}
+
+TEST_CASE("MathUtils: Smootherstep value", "[Math]") {
+	CHECK(Fl::MathUtils::Smootherstep(0.f) == 0.f);
+	CHECK(Fl::MathUtils::Smootherstep(0.25f) == 0.103515625f);
+	CHECK(Fl::MathUtils::Smootherstep(0.5f) == 0.5f);
+	CHECK(Fl::MathUtils::Smootherstep(0.75f) == 0.89648438f);
+	CHECK(Fl::MathUtils::Smootherstep(1.f) == 1.f);
+}
+
+TEST_CASE("MathUtils: Smootherstep range", "[Math]") {
+	CHECK(Fl::MathUtils::Smootherstep(0.f, 1.f, -1.f) == 0.f); // If value < minThresh, returns 0
+	CHECK(Fl::MathUtils::Smootherstep(0.f, 1.f, 0.f) == 0.f);
+	CHECK(Fl::MathUtils::Smootherstep(0.f, 1.f, 0.25f) == 0.103515625f);
+	CHECK(Fl::MathUtils::Smootherstep(0.f, 1.f, 0.5f) == 0.5f);
+	CHECK(Fl::MathUtils::Smootherstep(0.f, 1.f, 0.75f) == 0.89648438f);
+	CHECK(Fl::MathUtils::Smootherstep(0.f, 1.f, 1.f) == 1.f);
+	CHECK(Fl::MathUtils::Smootherstep(0.f, 1.f, 2.f) == 1.f); // If value > maxThresh, returns 1
+
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, -10.f) == 0.f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, -5.f - std::numeric_limits<float>::epsilon()) == 0.f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, -5.f) == 0.f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, -4.5f) == 0.0011581251f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, -2.5f) == 0.103515625f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, -0.5f) == 0.40687308f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, 0.f) == 0.5f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, 0.5f) == 0.59312695f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, 2.5f) == 0.89648438f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, 4.5f) == 0.99884182f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, 5.f) == 1.f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, 5.f + std::numeric_limits<float>::epsilon()) == 1.f);
+	CHECK(Fl::MathUtils::Smootherstep(-5.f, 5.f, 10.f) == 1.f);
+}
+
+TEST_CASE("MathUtils: Orthonormal basis", "[Math]") {
+	Fl::Vec3f axis2;
+	Fl::Vec3f axis3;
+
+	Fl::MathUtils::ComputeOrthonormalBasis(Fl::Axis::X, axis2, axis3);
+	CHECK(axis2 == -Fl::Axis::Z);
+	CHECK(axis3 == Fl::Axis::Y);
+
+	Fl::MathUtils::ComputeOrthonormalBasis(Fl::Axis::Y, axis2, axis3);
+	CHECK(axis2 == Fl::Axis::X);
+	CHECK(axis3 == -Fl::Axis::Z);
+
+	Fl::MathUtils::ComputeOrthonormalBasis(Fl::Axis::Z, axis2, axis3);
+	CHECK(axis2 == Fl::Axis::X);
+	CHECK(axis3 == Fl::Axis::Y);
+
+	Fl::MathUtils::ComputeOrthonormalBasis(Fl::Vec3f(1.f).Normalize(), axis2, axis3);
+	CHECK(axis2 == Fl::Vec3f(0.788675f, -0.211324856f, -0.577350259f));
+	CHECK(axis3 == Fl::Vec3f(-0.211324856f, 0.788675f, -0.577350259f));
+	CHECK(axis2.Dot(axis3) == 0.f);
+
+	Fl::MathUtils::ComputeOrthonormalBasis(Fl::Vec3f(-1.f).Normalize(), axis2, axis3);
+	CHECK(axis2 == Fl::Vec3f(0.788675f, -0.211324856f, -0.577350259f));
+	CHECK(axis3 == Fl::Vec3f(0.211324856f, -0.788675f, 0.577350259f));
+	CHECK(axis2.Dot(axis3) == 0.f);
+}
+
+TEST_CASE("MathUtils: Fibonacci sphere", "[Math]") {
+	std::vector<Fl::Vec3f> fiboPoints = Fl::MathUtils::ComputeFibonacciSpherePoints(0);
+	CHECK(fiboPoints.empty());
+
+	fiboPoints = Fl::MathUtils::ComputeFibonacciSpherePoints(1);
+	REQUIRE(fiboPoints.size() == 1);
+	CHECK_THAT(fiboPoints[0], IsNearlyEqualToVector(Fl::Vec3f(1.f, 0.f, 0.f)));
+
+	fiboPoints = Fl::MathUtils::ComputeFibonacciSpherePoints(2);
+	REQUIRE(fiboPoints.size() == 2);
+	CHECK_THAT(fiboPoints[0], IsNearlyEqualToVector(Fl::Vec3f(0.8660253f, 0.5f, 0.f)));
+	CHECK_THAT(fiboPoints[1], IsNearlyEqualToVector(Fl::Vec3f(-0.6385802f, -0.5, -0.5849917f)));
+
+	fiboPoints = Fl::MathUtils::ComputeFibonacciSpherePoints(3);
+	REQUIRE(fiboPoints.size() == 3);
+	CHECK_THAT(fiboPoints[0], IsNearlyEqualToVector(Fl::Vec3f(0.745356f, 0.6666666f, 0.f)));
+	CHECK_THAT(fiboPoints[1], IsNearlyEqualToVector(Fl::Vec3f(-0.7373688f, 0.f, -0.6754903f)));
+	CHECK_THAT(fiboPoints[2], IsNearlyEqualToVector(Fl::Vec3f(0.0651632f, -0.6666666f, 0.742502f)));
+
+	fiboPoints = Fl::MathUtils::ComputeFibonacciSpherePoints(4);
+	REQUIRE(fiboPoints.size() == 4);
+	CHECK_THAT(fiboPoints[0], IsNearlyEqualToVector(Fl::Vec3f(0.6614378f, 0.75f, 0.f)));
+	CHECK_THAT(fiboPoints[1], IsNearlyEqualToVector(Fl::Vec3f(-0.7139543f, 0.25f, -0.6540406f)));
+	CHECK_THAT(fiboPoints[2], IsNearlyEqualToVector(Fl::Vec3f(0.0846495f, -0.25f, 0.9645385f)));
+	CHECK_THAT(fiboPoints[3], IsNearlyEqualToVector(Fl::Vec3f(0.4024442f, -0.75f, -0.5249176f)));
+
+	fiboPoints = Fl::MathUtils::ComputeFibonacciSpherePoints(5);
+	REQUIRE(fiboPoints.size() == 5);
+	CHECK_THAT(fiboPoints[0], IsNearlyEqualToVector(Fl::Vec3f(0.6f, 0.8f, 0.f)));
+	CHECK_THAT(fiboPoints[1], IsNearlyEqualToVector(Fl::Vec3f(-0.6758097f, 0.3999999f, -0.619097f)));
+	CHECK_THAT(fiboPoints[2], IsNearlyEqualToVector(Fl::Vec3f(0.0874256f, 0.f, 0.996171f)));
+	CHECK_THAT(fiboPoints[3], IsNearlyEqualToVector(Fl::Vec3f(0.5576431f, -0.3999999f, -0.7273473f)));
+	CHECK_THAT(fiboPoints[4], IsNearlyEqualToVector(Fl::Vec3f(-0.5908281f, -0.7999999f, 0.104509f)));
+}

--- a/tests/Source/Math/Vector.cpp
+++ b/tests/Source/Math/Vector.cpp
@@ -1,0 +1,599 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#include <FlashlightEngine/Math/Matrix.hpp>
+#include <FlashlightEngine/Math/Vector.hpp>
+#include <FlashlightEngine/Math/FloatMath.hpp>
+
+#include <FlTests/CustomMatchers.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <unordered_map>
+#include <utility>
+
+namespace {
+	// Declaring vectors to be tested.
+
+	constexpr Fl::Vec3b vec3b1(31, 8, 12);
+	constexpr Fl::Vec3b vec3b2(48, 255, 0);
+
+	constexpr Fl::Vec3i vec3i1(-48, 0, 18742);
+	constexpr Fl::Vec3i vec3i2(740, -1058, 18);
+
+	constexpr Fl::Vec3f vec3f1(3.18f, 42.f, 0.874f);
+	constexpr Fl::Vec3f vec3f2(541.41f, 47.25f, 6.321f);
+
+	constexpr Fl::Vec4f vec4f1(84.47f, 2.f, 0.001f, 847.12f);
+	constexpr Fl::Vec4f vec4f2(13.01f, 0.15f, 84.8f, 72.f);
+
+	constexpr Fl::Vec3d vec3d1(-18.1, 4752.001, -842.0);
+	constexpr Fl::Vec3d vec3d2(13.01, -0.00000001, 351.025465545);
+}
+
+TEST_CASE("Vector: Deduction guides", "[Math]") {
+	constexpr Fl::Vector vec3b(static_cast<uint8_t>(1), 2, 3);
+	constexpr Fl::Vector vec2i(1, 2);
+	constexpr Fl::Vector vec4u(1u, 2u, 3u, 4u);
+	constexpr Fl::Vector vec3f(1.f, 2.f, 3.f);
+	constexpr Fl::Vector vec5d(1.0, 2.0, 3.0, 4.0, 5.0);
+
+	CHECK(std::is_same_v<std::decay_t<decltype(vec3b)>, Fl::Vec3b>);
+	CHECK(std::is_same_v<std::decay_t<decltype(vec2i)>, Fl::Vec2i>);
+	CHECK(std::is_same_v<std::decay_t<decltype(vec4u)>, Fl::Vec4u>);
+	CHECK(std::is_same_v<std::decay_t<decltype(vec3f)>, Fl::Vec3f>);
+	CHECK(std::is_same_v<std::decay_t<decltype(vec5d)>, Fl::Vector<double, 5>>);
+}
+
+TEST_CASE("Vector: Indexing", "[Math]") {
+	CHECK(vec3f1[0] == 3.18f);
+	CHECK(vec3f1[1] == 42.f);
+	CHECK(vec3f1[2] == 0.874f);
+
+	CHECK(vec3f1.X() == 3.18f);
+	CHECK(vec3f1.Y() == 42.f);
+	CHECK(vec3f1.Z() == 0.874f);
+
+	Fl::Vec4f vecCopy = vec4f1;
+
+	vecCopy[0] += 1.f;
+	vecCopy[1] += 1.f;
+	vecCopy[2] += 1.f;
+	vecCopy[3] += 1.f;
+
+	vecCopy.X() += 1.f;
+	vecCopy.Y() += 1.f;
+	vecCopy.Z() += 1.f;
+	vecCopy.W() += 1.f;
+
+	CHECK(vecCopy[0] == vec4f1[0] + 2.f);
+	CHECK(vecCopy[1] == vec4f1[1] + 2.f);
+	CHECK(vecCopy[2] == vec4f1[2] + 2.f);
+	CHECK(vecCopy[3] == vec4f1[3] + 2.f);
+
+	CHECK(vecCopy.X() == vec4f1.X() + 2.f);
+	CHECK(vecCopy.Y() == vec4f1.Y() + 2.f);
+	CHECK(vecCopy.Z() == vec4f1.Z() + 2.f);
+	CHECK(vecCopy.W() == vec4f1.W() + 2.f);
+}
+
+TEST_CASE("Vector: Dot product", "[Math]") {
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3b>().Dot(std::declval<Fl::Vec3b>())), Fl::U64>);
+	CHECK(vec3b1.Dot(vec3b2) == 3528);
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3i>().Dot(std::declval<Fl::Vec3i>())), Fl::U64>);
+	CHECK(vec3i1.Dot(vec3i2) == 301836);
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3f>().Dot(std::declval<Fl::Vec3f>())), float>);
+	CHECK(vec3f1.Dot(vec3f1) == vec3f1.ComputeSquaredLength());
+	CHECK_THAT(vec3f1.Dot(vec3f1), IsNearlyEqualTo(1774.876276f));
+	CHECK_THAT(vec3f1.Dot(vec3f2), IsNearlyEqualTo(3711.708354f));
+	CHECK(vec3f1.Dot(vec3f2) == vec3f2.Dot(vec3f1)); // A dot B == B dot A
+
+	CHECK_THAT(vec4f1.Dot(vec4f2), IsNearlyEqualTo(62091.98f));
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3d>().Dot(std::declval<Fl::Vec3d>())), double>);
+	CHECK_THAT(vec3d1.Dot(vec3d2), IsNearlyEqualTo(-295798.92303641));
+}
+
+TEST_CASE("Vector: Cross product", "[Math]") {
+	// The cross product cannot be computed for unsigned types or sizes other than 3
+
+	CHECK(vec3i1.Cross(vec3i1) == Fl::Vec3i(0));
+	CHECK(vec3i1.Cross(vec3i2) == Fl::Vec3i(19829036, 13869944, 50784));
+
+	CHECK_THAT(vec3f1.Cross(vec3f1), IsNearlyEqualToVector(Fl::Vec3f(0.f), 0.00001f)); // Clang in Release gives values above the default tolerance
+	CHECK_THAT(vec3f1.Cross(vec3f2), IsNearlyEqualToVector(Fl::Vec3f(224.1855f, 453.09156f, -22588.965f)));
+	CHECK(vec3f1.Cross(vec3f2) == -vec3f2.Cross(vec3f1)); // A x B == -(B x A)
+
+	CHECK_THAT(vec3d1.Cross(vec3d1), IsNearlyEqualToVector(Fl::Vec3d(0.0), 0.00001f));
+	CHECK_THAT(vec3d1.Cross(vec3d2), IsNearlyEqualToVector(Fl::Vec3d(1668073.3632868854, -4600.859073635499, -61823.533009819)));
+}
+
+TEST_CASE("Vector: Scalar operations", "[Math]") {
+	CHECK((vec3b1 + 4) == Fl::Vec3b(35, 12, 16));
+	CHECK((vec3b2 - 8) == Fl::Vec3b(40, 247, 248)); // Underflowing from 0 to 248 (255 - 7)
+	CHECK((vec3b1 * 2) == Fl::Vec3b(62, 16, 24));
+	CHECK((vec3b2 / 3) == Fl::Vec3b(16, 85, 0));
+
+	CHECK((vec3i1 + 72) == Fl::Vec3i(24, 72, 18814));
+	CHECK((vec3i2 - 20) == Fl::Vec3i(720, -1078, -2));
+	CHECK((vec3i1 * 5)  == Fl::Vec3i(-240, 0, 93710));
+	CHECK((vec3i2 / 10) == Fl::Vec3i(74, -105, 1));
+
+	// Floating-point operations
+
+	CHECK((vec3f1 + 3.5f) == Fl::Vec3f(6.68f, 45.5f, 4.374f));
+	CHECK((vec3f2 - 74.42f) == Fl::Vec3f(466.99f, -27.17f, -68.099f));
+	CHECK((vec3f1 + 8.2f) == (8.2f + vec3f1));
+
+	CHECK((vec3f1 * 3.f) == Fl::Vec3f(9.54f, 126.f, 2.622f));
+	CHECK((vec3f1 * 4.152f) == Fl::Vec3f(13.20336f, 174.384f, 3.628848f));
+	CHECK((vec3f1 * 6.31f) == (6.31f * vec3f1));
+
+	CHECK((vec4f1 * 7.5f) == Fl::Vec4f(633.525f, 15.f, 0.0075f, 6353.4f));
+	CHECK((vec4f1 * 8.0002f) == Fl::Vec4f(675.776894f, 16.0004f, 0.0080002f, 6777.129424f));
+	CHECK((vec4f1 * 0.f) == Fl::Vec4f(0.f, 0.f, 0.f, 0.f));
+
+	CHECK((vec3f1 / 2.f) == Fl::Vec3f(1.59f, 21.f, 0.437f));
+	CHECK((vec4f2 / 7.32f) == Fl::Vec4f(1.777322404f, 0.0204918f, 11.58469945f, 9.83606557f));
+
+	// If IEEE 754 is supported, check that division by 0 behaves as expected
+
+	if constexpr (std::numeric_limits<float>::is_iec559) {
+		const Fl::Vec3f vecInf = vec3f1 / 0.f;
+		CHECK(vecInf[0] == std::numeric_limits<float>::infinity());
+		CHECK(vecInf[1] == std::numeric_limits<float>::infinity());
+		CHECK(vecInf[2] == std::numeric_limits<float>::infinity());
+
+		const Fl::Vec3f vecNaN = Fl::Vec3f(0.f) / 0.f;
+		CHECK(std::isnan(vecNaN[0]));
+		CHECK(std::isnan(vecNaN[1]));
+		CHECK(std::isnan(vecNaN[2]));
+	}
+
+	if constexpr (std::numeric_limits<double>::is_iec559) {
+		const Fl::Vec3d vecInf = vec3d1 / 0.0;
+		CHECK(vecInf[0] == -std::numeric_limits<double>::infinity());
+		CHECK(vecInf[1] == std::numeric_limits<double>::infinity());
+		CHECK(vecInf[2] == -std::numeric_limits<double>::infinity());
+
+		const Fl::Vec3d vecNaN = Fl::Vec3d(0.0) / 0.0;
+		CHECK(std::isnan(vecNaN[0]));
+		CHECK(std::isnan(vecNaN[1]));
+		CHECK(std::isnan(vecNaN[2]));
+	}
+}
+
+TEST_CASE("Vector: Operations between vectors", "[Math]") {
+	CHECK((vec3b1 + vec3b2) == Fl::Vec3b(79, 7, 12)); // Values are overflowed
+	CHECK((vec3b1 - vec3b2) == Fl::Vec3b(239, 9, 12)); // Values are underflowed
+	CHECK((vec3b1 * vec3b2) == Fl::Vec3b(208, 248, 0)); // Values are overflowed
+	CHECK((vec3b1 / (vec3b2 + Fl::Vec3b(0, 0, 1))) == Fl::Vec3b(0, 0, 12)); // Adding 1 to Z to avoid dividing by 0
+
+	CHECK(-vec3i1 == Fl::Vec3i(48, 0, -18742));
+	CHECK((vec3i1 + vec3i2) == Fl::Vec3i(692, -1058, 18760));
+	CHECK((vec3i1 - vec3i2) == Fl::Vec3i(-788, 1058, 18724));
+	CHECK((vec3i1 * vec3i2) == Fl::Vec3i(-35520, 0, 337356));
+	CHECK((vec3i1 / vec3i2) == Fl::Vec3i(0, 0, 1041));
+
+	CHECK((-vec3f1).StrictlyEquals(Fl::Vec3f(-3.18f, -42.f, -0.874f)));
+	CHECK_THAT(vec3f1 + vec3f1, IsNearlyEqualToVector(vec3f1 * 2));
+	CHECK_THAT(vec3f1 - vec3f1, IsNearlyEqualToVector(Fl::Vec3f(0.f)));
+	CHECK_THAT(vec3f1 * vec3f2, IsNearlyEqualToVector(Fl::Vec3f(1721.6838f, 1984.5f, 5.524554f)));
+	CHECK_THAT(vec3f1 / vec3f2, IsNearlyEqualToVector(Fl::Vec3f(0.00587355f, 0.888889f, 0.1382692f)));
+
+	CHECK_THAT(vec4f1 * vec4f2, IsNearlyEqualToVector(Fl::Vec4f(1098.9547f, 0.3, 0.0848, 60992.64)));
+	CHECK_THAT(vec4f1 / vec4f2, IsNearlyEqualToVector(Fl::Vec4f(6.4926977, 13.333333, 0.0000117, 11.765555)));
+
+	CHECK((-vec3d1).StrictlyEquals(Fl::Vec3d(18.1, -4752.001, 842.0)));
+	CHECK_THAT(vec3d1 + vec3d1, IsNearlyEqualToVector(vec3d1 * 2));
+	CHECK_THAT(vec3d1 - vec3d1, IsNearlyEqualToVector(Fl::Vec3d(0.0)));
+	CHECK_THAT(vec3d1 * vec3d2, IsNearlyEqualToVector(Fl::Vec3d(-235.481, -0.0000475200099999, -295563.44198889)));
+	CHECK_THAT(vec3d1 / vec3d2, IsNearlyEqualToVector(Fl::Vec3d(-1.391237509607994, -475200100000.0, -2.3986863707814358)));
+}
+
+TEST_CASE("Vector: Matrix operations", "[Math]") {
+	const Fl::Mat3f mat3(4.12f, 25.1f, 30.7842f,
+		                 3.04f, 5.f, -64.5f,
+		                 -1.f, -7.54f, 8.41f);
+	CHECK((vec3f1 * mat3) == Fl::Vec3f(139.9076f, 283.22804f, -2603.755904f));
+	CHECK((vec3f2 * mat3) == Fl::Vec3f(2367.9282f, 13'777.980'66f, 13'672.408'332f));
+
+	const Fl::Mat4f mat4(-3.2f, 53.032f, 832.451f, 74.2f,
+		                 10.01f, 3.15f, -91.41f, 187.46f,
+		                 -6.f, -7.78f, 90.f, 38.f,
+		                 123.f, -74.8f, 147.0001f, 748.6f);
+	CHECK((vec4f1 * mat4) == Fl::Vec4f(103'945.47f, -58878.67074f, 194'661.130'682f, 640'796.664f));
+	CHECK((vec4f2 * mat4) == Fl::Vec4f(8307.0695f, -5354.92518f, 29032.48321f, 58115.061f));
+
+	CHECK((vec3f1 * Fl::Mat3f::Identity()) == vec3f1);
+	CHECK((vec4f1 * Fl::Mat4f::Identity()) == vec4f1);
+}
+
+TEST_CASE("Vector: Reflection", "[Math]") {
+	// IncVec  N  Reflection
+	//      \  ^  ^
+	//       \ | /
+	// _______v|/_______
+
+	// The reflected vector cannot be computed for unsigned types
+
+	CHECK(Fl::Vec3f(1.f, -1.f, 0.f).Reflect(Fl::Vec3f(0.f, 1.f, 0.f)) == Fl::Vec3f(1.f, 1.f, 0.f));
+	CHECK_THAT(vec3f1.Reflect(Fl::Vec3f(0.f, 1.f, 0.f)), IsNearlyEqualToVector(Fl::Vec3f(3.18f, -42.f, 0.874f)));
+	CHECK_THAT(vec3f1.Reflect(vec3f2), IsNearlyEqualToVector(Fl::Vec3f(-4019108.85987828f, -350714.439453f, -46922.543011268f)));
+
+	CHECK(Fl::Vec3d(0.0, 1.0, 0.0).Reflect(Fl::Vec3d(-1.0, -1.0, 0.0)) == Fl::Vec3d(-2.0, -1.0, 0.0));
+	CHECK_THAT(vec3d1.Reflect(Fl::Vec3d(0.0, 1.0, 0.0)), IsNearlyEqualToVector(Fl::Vec3d(-18.1, -4752.001, -842.0)));
+	CHECK_THAT(vec3d1.Reflect(vec3d2), IsNearlyEqualToVector(Fl::Vec3d(7696669.877407388, 4751.995084021539, 207665067.33313086)));
+}
+
+TEST_CASE("Vector: Length", "[Math]") {
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3b>().ComputeSquaredLength()), Fl::U64>);
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3b>().ComputeLength()), float>);
+	CHECK(vec3b1.ComputeSquaredLength() == 1169);
+	CHECK(vec3b1.ComputeLength() == 34.190643311f);
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3i>().ComputeSquaredLength()), Fl::U64>);
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3i>().ComputeLength()), float>);
+	CHECK(vec3i1.ComputeSquaredLength() == 351264868);
+	CHECK(vec3i1.ComputeLength() == 18742.060546875f);
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3f>().ComputeSquaredLength()), float>);
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3f>().ComputeLength()), float>);
+	CHECK(vec3f1.ComputeSquaredLength() == 1774.876342773f);
+	CHECK(vec3f1.ComputeLength() == 42.12928009f);
+
+	CHECK_THAT(vec4f1.ComputeSquaredLength(), IsNearlyEqualTo(724751.5f));
+	CHECK_THAT(vec4f1.ComputeLength(), IsNearlyEqualTo(851.323364258f));
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3d>().ComputeSquaredLength()), double>);
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3d>().ComputeLength()), double>);
+	CHECK(vec3d1.ComputeSquaredLength() == 23290805.114001002);
+	CHECK(vec3d1.ComputeLength() == 4826.054818793607);
+}
+
+TEST_CASE("Vector: Normalization", "[Math]") {
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3b>().Normalize()), Fl::Vec3f>);
+	CHECK_THAT(vec3b1.Normalize(), IsNearlyEqualToVector(Fl::Vec3f(0.9066808f, 0.2339821f, 0.3509732f)));
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3i>().Normalize()), Fl::Vec3f>);
+	CHECK_THAT(vec3i1.Normalize(), IsNearlyEqualToVector(Fl::Vec3f(-0.00256108f, 0.f, 0.9999967f)));
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3f>().Normalize()), Fl::Vec3f>);
+	CHECK_THAT(vec3f1.Normalize(), IsNearlyEqualToVector(Fl::Vec3f(0.0754819f, 0.9969313f, 0.0207457f)));
+	CHECK_THAT(vec4f1.Normalize(), IsNearlyEqualToVector(Fl::Vec4f(0.0992219f, 0.0023492f, 0.0000011f, 0.9950625f)));
+
+	CHECK_THAT(vec4f1.Normalize().ComputeSquaredLength(), IsNearlyEqualTo(1.f));
+	CHECK_THAT(vec3f1.Normalize().ComputeLength(), IsNearlyEqualTo(1.f));
+
+	CHECK(std::is_same_v<decltype(std::declval<Fl::Vec3d>().Normalize()), Fl::Vec3d>);
+	CHECK_THAT(vec3d1.Normalize(), IsNearlyEqualToVector(Fl::Vec3d(-0.0037504754254997, 0.9846554128425506, -0.174469630291203)));
+
+	// Normalizing a 0 vector returns it as is
+	CHECK(Fl::Vec3b(0).Normalize() == Fl::Vec3f(0.f));
+	CHECK(Fl::Vec3i(0).Normalize() == Fl::Vec3f(0.f));
+	CHECK(Fl::Vec3f(0.f).Normalize() == Fl::Vec3f(0.f));
+	CHECK(Fl::Vec3d(0.0).Normalize() == Fl::Vec3d(0.f));
+}
+
+TEST_CASE("Vector: Interpolation", "[Math]") {
+	CHECK(vec3b1.Lerp(vec3b2, 0.f) == vec3b1);
+	CHECK(vec3b1.Lerp(vec3b2, 0.25f) == Fl::Vec3b(35, 69, 9)); // Results are truncated, not rounded
+	CHECK(vec3b1.Lerp(vec3b2, 0.5f) == Fl::Vec3b(39, 131, 6));
+	CHECK(vec3b1.Lerp(vec3b2, 0.75f) == Fl::Vec3b(43, 193, 3));
+	CHECK(vec3b1.Lerp(vec3b2, 1.f) == vec3b2);
+
+	// The resulting interpolated vector's type can be manually chosen
+	CHECK(vec3b1.Lerp<float>(vec3b2, 0.f) == Fl::Vec3f(vec3b1));
+	CHECK(vec3b1.Lerp<float>(vec3b2, 0.25f) == Fl::Vec3f(35.25f, 69.75f, 9.f));
+	CHECK(vec3b1.Lerp<float>(vec3b2, 0.5f) == Fl::Vec3f(39.5f, 131.5f, 6.f));
+	CHECK(vec3b1.Lerp<float>(vec3b2, 0.75f) == Fl::Vec3f(43.75f, 193.25f, 3.f));
+	CHECK(vec3b1.Lerp<float>(vec3b2, 1.f) == Fl::Vec3f(vec3b2));
+
+	// Computing the lerp as-is then normalizing the result truncates the values, as Lerp()'s returned vector is of the original type by default
+	CHECK_THAT(vec3b1.Lerp(vec3b2, 0.5f).Normalize(), IsNearlyEqualToVector(Fl::Vec3f(0.285059f, 0.9575061f, 0.0438552f)));
+	// Computing the normalized linear interpolation does the lerp with the same result type as it uses itself; no truncation happens
+	CHECK_THAT(vec3b1.NLerp(vec3b2, 0.5f), IsNearlyEqualToVector(Fl::Vec3f(0.2874076f, 0.956813f, 0.0436569f)));
+
+	CHECK(vec3i1.Lerp(vec3i2, 0.f) == vec3i1);
+	CHECK(vec3i1.Lerp(vec3i2, 0.25f) == Fl::Vec3i(149, -264, 14061));
+	CHECK(vec3i1.Lerp(vec3i2, 0.5f) == Fl::Vec3i(346, -529, 9380));
+	CHECK(vec3i1.Lerp(vec3i2, 0.75f) == Fl::Vec3i(543, -793, 4699));
+	CHECK(vec3i1.Lerp(vec3i2, 1.f) == vec3i2);
+	CHECK(vec3i1.NLerp(vec3i2, 0.5f) == Fl::Vec3f(0.0368035f, -0.056269f, 0.997737f));
+
+	// Lerp() doesn't normalize the resulting vector
+	CHECK(vec3f1.Lerp(vec3f2, 0.f) == vec3f1);
+	CHECK(vec3f1.Lerp(vec3f2, 0.25f) == Fl::Vec3f(137.73749f, 43.3125f, 2.23575f)); // (vec3f1 * 3 + vec3f2) / 4
+	CHECK(vec3f1.Lerp(vec3f2, 0.5f) == (vec3f1 + vec3f2) / 2);
+	CHECK(vec3f1.Lerp(vec3f2, 0.75f) == Fl::Vec3f(406.85248f, 45.9375f, 4.95925f)); // (vec3f1 + vec3f2 * 3) / 4
+	CHECK(vec3f1.Lerp(vec3f2, 1.f) == vec3f2);
+
+	// nlerp() does normalize the resulting vector; it is strictly equal to vec.lerp(...).normalize()
+	CHECK(vec4f1.NLerp(vec4f2, 0.f) == vec4f1.Normalize());
+	CHECK(vec4f1.NLerp(vec4f2, 0.25f) == Fl::Vec4f(0.10136666f, 0.00233993f, 0.0322656f, 0.994323f)); // (vec4f1 * 3 + vec4f2).Normalize()
+	CHECK(vec4f1.NLerp(vec4f2, 0.5f) == (vec4f1 + vec4f2).Normalize());
+	CHECK(vec4f1.NLerp(vec4f2, 0.75f) == Fl::Vec4f(0.11226334f, 0.00222709f, 0.23125429f, 0.966392f)); // (vec4f1 + vec4f2 * 3).Normalize()
+	CHECK(vec4f1.NLerp(vec4f2, 1.f) == vec4f2.Normalize());
+
+	CHECK_THAT(vec3d1.Lerp(vec3d2, 0.0), IsNearlyEqualToVector(vec3d1));
+	CHECK_THAT(vec3d1.Lerp(vec3d2, 0.25), IsNearlyEqualToVector(Fl::Vec3d(-10.3225, 3564.0007499974999, -543.74363361375)));
+	CHECK_THAT(vec3d1.Lerp(vec3d2, 0.5), IsNearlyEqualToVector((vec3d1 + vec3d2) / 2, 0.000000000000001));
+	CHECK_THAT(vec3d1.Lerp(vec3d2, 0.75), IsNearlyEqualToVector(Fl::Vec3d(5.232499999999998, 1188.0002499925003, 52.76909915874989)));
+	CHECK_THAT(vec3d1.Lerp(vec3d2, 1.0), IsNearlyEqualToVector(vec3d2, 0.000000000001));
+}
+
+TEST_CASE("Vector: Structure bindings", "[Math]") {
+	static_assert(std::tuple_size_v<decltype(vec3b1)> == 3);
+	static_assert(std::tuple_size_v<decltype(vec4f1)> == 4);
+	static_assert(std::tuple_size_v<decltype(Fl::Vector<bool, 1>())> == 1);
+
+	static_assert(std::is_same_v<std::tuple_element_t<0, decltype(vec3i1)>, const int>);
+	static_assert(std::is_same_v<std::tuple_element_t<2, decltype(vec3d1)>, const double>);
+	static_assert(std::is_same_v<std::tuple_element_t<0, decltype(Fl::Vector<bool, 1>())>, bool>);
+	static_assert(std::is_same_v<std::tuple_element_t<0, decltype(Fl::Vector<const bool, 1>())>, const bool>);
+	static_assert(std::is_same_v<std::tuple_element_t<0, std::add_const_t<decltype(Fl::Vector<bool, 1>())>>, const bool>);
+
+	// When using structured bindings, Fl::get<I>(e) is exclusively found using ADL (https://en.cppreference.com/w/cpp/language/adl)
+	static_assert(Fl::get<0>(vec3f1) == vec3f1[0]);
+	static_assert(Fl::get<1>(vec3f1) == vec3f1[1]);
+	static_assert(Fl::get<2>(vec3f1) == vec3f1[2]);
+
+	{
+		const auto [x, y, z] = vec3b2;
+		static_assert(std::is_same_v<decltype(x), const uint8_t>);
+		static_assert(std::is_same_v<decltype(y), const uint8_t>);
+		static_assert(std::is_same_v<decltype(z), const uint8_t>);
+
+		CHECK(x == vec3b2.X());
+		CHECK(y == vec3b2.Y());
+		CHECK(z == vec3b2.Z());
+
+		// Elements are new variables
+		CHECK_FALSE(&x == &vec3b2.X());
+		CHECK_FALSE(&y == &vec3b2.Y());
+		CHECK_FALSE(&z == &vec3b2.Z());
+	}
+
+	{
+		const auto& [x, y, z] = vec3d2;
+		// decltype-ing a structured binding doesn't show a reference...
+		static_assert(std::is_same_v<decltype(x), const double>);
+		static_assert(std::is_same_v<decltype(y), const double>);
+		static_assert(std::is_same_v<decltype(z), const double>);
+		// ... but getting the elements independently does...
+		static_assert(std::is_same_v<decltype(Fl::get<0>(vec3d2)), const double&>);
+		static_assert(std::is_same_v<decltype(Fl::get<1>(vec3d2)), const double&>);
+		static_assert(std::is_same_v<decltype(Fl::get<2>(vec3d2)), const double&>);
+
+		CHECK(x == vec3d2.X());
+		CHECK(y == vec3d2.Y());
+		CHECK(z == vec3d2.Z());
+
+		// ... and the elements are linked as expected
+		CHECK(&x == &vec3d2.X());
+		CHECK(&y == &vec3d2.Y());
+		CHECK(&z == &vec3d2.Z());
+	}
+
+	{
+		Fl::Vector<bool, 1> boolVec(38);
+
+		{
+			const auto [x] = boolVec;
+			static_assert(std::is_same_v<decltype(x), const bool>);
+			CHECK(x == boolVec.X());
+			CHECK_FALSE(&x == &boolVec.X());
+		}
+
+		{
+			auto [x] = boolVec;
+			static_assert(std::is_same_v<decltype(x), bool>);
+			CHECK(x == boolVec.X());
+			CHECK_FALSE(&x == &boolVec.X());
+		}
+
+		{
+			const auto& [x] = boolVec;
+			static_assert(std::is_same_v<decltype(x), const bool>);
+			static_assert(std::is_same_v<decltype(Fl::get<0>(std::as_const(boolVec))), const bool&>);
+			CHECK(x == boolVec.X());
+			CHECK(&x == &boolVec.X());
+		}
+
+		{
+			auto& [x] = boolVec;
+			static_assert(std::is_same_v<decltype(x), bool>);
+			static_assert(std::is_same_v<decltype(Fl::get<0>(boolVec)), bool&>);
+			CHECK(x == boolVec.X());
+			CHECK(&x == &boolVec.X());
+		}
+
+		{
+			auto&& [x] = std::move(boolVec);
+			static_assert(std::is_same_v<decltype(x), bool>);
+			static_assert(std::is_same_v<decltype(Fl::get<0>(std::move(boolVec))), bool&&>); // xvalue
+			static_assert(std::is_same_v<decltype(Fl::get<0>(Fl::Vector<bool, 1>())), bool&&>); // prvalue
+			CHECK(x == boolVec.X());
+			CHECK(&x == &boolVec.X());
+		}
+	}
+}
+
+TEST_CASE("Vector: Hash", "[Math]") {
+	CHECK(vec3b1.Hash() == vec3b1.Hash());
+	CHECK_FALSE(vec3b1.Hash() == vec3b2.Hash());
+
+	CHECK(vec3i1.Hash() == vec3i1.Hash());
+	CHECK_FALSE(vec3i1.Hash() == vec3i2.Hash());
+
+	CHECK(vec3f1.Hash() == vec3f1.Hash());
+	CHECK_FALSE(vec3f1.Hash() == vec3f2.Hash());
+
+	CHECK(vec4f1.Hash() == vec4f1.Hash());
+	CHECK_FALSE(vec4f1.Hash() == vec4f2.Hash());
+
+	CHECK(vec3d1.Hash() == vec3d1.Hash());
+	CHECK_FALSE(vec3d1.Hash() == vec3d2.Hash());
+
+	constexpr Fl::Vec3f vec3f1Swizzled(vec3f1[2], vec3f1[0], vec3f1[1]);
+	CHECK_FALSE(vec3f1.Hash() == vec3f1Swizzled.Hash());
+
+	constexpr Fl::Vec3f vec3f1Epsilon = vec3f1 + std::numeric_limits<float>::epsilon();
+	CHECK_FALSE(vec3f1.Hash() == vec3f1Epsilon.Hash());
+
+	// Checking that it behaves as expected when used in a hashmap
+	std::unordered_map<Fl::Vec3f, int> map;
+	map.try_emplace(vec3f1, 1);
+	map.try_emplace(vec3f1Swizzled, 2);
+	map.try_emplace(vec3f1Epsilon, 3);
+	map.try_emplace(vec3f2, 4);
+
+	CHECK(map.size() == 4);
+
+	CHECK(map.find(vec3f1)->second == 1);
+	CHECK(map.find(vec3f1Swizzled)->second == 2);
+	CHECK(map.find(vec3f1Epsilon)->second == 3);
+	CHECK(map.find(vec3f2)->second == 4);
+
+	map.erase(vec3f1Epsilon);
+	CHECK(map.find(vec3f1Epsilon) == map.cend());
+}
+
+TEST_CASE("Vector: Near-equality", "[Math]") {
+	// Near-equality applies only to vectors of floating-point values
+
+	CHECK_FALSE(vec3f1 == vec3f2);
+
+	constexpr Fl::Vec3f baseVec(1.f);
+	Fl::Vec3f compVec = baseVec;
+
+	CHECK(baseVec[0] == compVec[0]); // Copied, strict equality
+	CHECK(baseVec[1] == compVec[1]);
+	CHECK(baseVec[2] == compVec[2]);
+
+	compVec += 0.0000001f; // Adding a tiny offset
+
+	CHECK_FALSE(baseVec[0] == compVec[0]); // Values not strictly equal
+	CHECK_FALSE(baseVec[1] == compVec[1]);
+	CHECK_FALSE(baseVec[2] == compVec[2]);
+
+	CHECK_THAT(baseVec[0], IsNearlyEqualTo(compVec[0])); // Near-equality components check
+	CHECK_THAT(baseVec[1], IsNearlyEqualTo(compVec[1]));
+	CHECK_THAT(baseVec[2], IsNearlyEqualTo(compVec[2]));
+
+	CHECK_THAT(baseVec, IsNearlyEqualToVector(compVec)); // Simpler check in a single call
+
+	CHECK(baseVec == compVec); // Vector::operator== does a near-equality check on floating point types
+}
+
+TEST_CASE("Vector: Strict equality", "[Math]") {
+	CHECK(vec3b1.StrictlyEquals(vec3b1));
+	CHECK_FALSE(vec3b1.StrictlyEquals(vec3b1 + Fl::Vec3b(1, 0, 0)));
+
+	CHECK(vec3i1.StrictlyEquals(vec3i1));
+	CHECK_FALSE(vec3i1.StrictlyEquals(vec3i1 + Fl::Vec3i(1, 0, 0)));
+
+	CHECK(vec3f1.StrictlyEquals(vec3f1));
+	CHECK(vec4f1.StrictlyEquals(vec4f1));
+
+	CHECK(std::equal_to<Fl::Vec3f>()(vec3f1, vec3f1));
+	CHECK(std::equal_to<Fl::Vec4f>()(vec4f1, vec4f1));
+
+	constexpr Fl::Vec3f vec3f1Swizzled(vec3f1[2], vec3f1[0], vec3f1[1]);
+	CHECK_FALSE(vec3f1.StrictlyEquals(vec3f1Swizzled));
+	CHECK_FALSE(std::equal_to<Fl::Vec3f>()(vec3f1, vec3f1Swizzled));
+
+	constexpr Fl::Vec3f vec3f1Epsilon = vec3f1 + std::numeric_limits<float>::epsilon();
+	CHECK(vec3f1 == vec3f1Epsilon); // Near-equality check
+	CHECK_FALSE(vec3f1.StrictlyEquals(vec3f1Epsilon)); // Strict-equality checks
+	CHECK_FALSE(std::equal_to<Fl::Vec3f>()(vec3f1, vec3f1Epsilon));
+
+	constexpr Fl::Vec3d vec3d2Epsilon = vec3d2 + std::numeric_limits<double>::epsilon();
+	CHECK(vec3d2 == vec3d2Epsilon); // Near-equality check
+	CHECK_FALSE(vec3d2.StrictlyEquals(vec3d2Epsilon)); // Strict-equality checks
+	CHECK_FALSE(std::equal_to<Fl::Vec3d>()(vec3d2, vec3d2Epsilon));
+
+	constexpr std::array<Fl::Vec3f, 3> vectors = { vec3f1Swizzled, vec3f1Epsilon, vec3f1 };
+
+	// When using a simple find(), which uses operator==, vec3f1Epsilon is found instead of vec3f1
+	const auto foundIter = std::find(vectors.cbegin(), vectors.cend(), vec3f1);
+	CHECK(std::distance(vectors.cbegin(), foundIter) == 1);
+
+	// To search for a specific element, find_if() must be used with a strict equality check
+	const auto foundIfIter = std::find_if(vectors.cbegin(), vectors.cend(), [&](const Fl::Vec3f& compVec) { return vec3f1.StrictlyEquals(compVec); });
+	CHECK(std::distance(vectors.cbegin(), foundIfIter) == 2);
+
+	constexpr std::array<Fl::Vec3f, 3> swappedVectors = { vec3f1Swizzled, vec3f1, vec3f1Epsilon };
+
+	// Trying to compare for equality fails with a simple std::equal on the vectors
+	CHECK(std::equal(vectors.cbegin(), vectors.cend(), swappedVectors.cbegin()));
+
+	// When using the std::equal_to specialization, vectors are properly found to be unequal to each other
+	CHECK_FALSE(std::equal(vectors.cbegin(), vectors.cend(), swappedVectors.cbegin(), std::equal_to<Fl::Vec3f>()));
+}
+
+TEST_CASE("Vector less-than", "[Math]") {
+	CHECK(std::less<Fl::Vec3b>()(vec3b1, vec3b2));
+	CHECK_FALSE(std::less<Fl::Vec3b>()(vec3b2, vec3b1));
+
+	CHECK(std::less<Fl::Vec3i>()(vec3i1, vec3i2));
+	CHECK_FALSE(std::less<Fl::Vec3i>()(vec3i2, vec3i1));
+
+	CHECK(std::less<Fl::Vec3f>()(vec3f1, vec3f2));
+	CHECK_FALSE(std::less<Fl::Vec3f>()(vec3f2, vec3f1));
+	CHECK_FALSE(std::less<Fl::Vec3f>()(vec3f1, vec3f1)); // Equal vectors are not strictly less than the other
+	CHECK(std::less<Fl::Vec3f>()(vec3f1, vec3f1 + std::numeric_limits<float>::epsilon()));
+	CHECK_FALSE(std::less<Fl::Vec3f>()(vec3f1 + std::numeric_limits<float>::epsilon(), vec3f1)); // Performs a strict check, no tolerance allowed
+
+	CHECK_FALSE(std::less<Fl::Vec4f>()(vec4f1, vec4f2));
+	CHECK(std::less<Fl::Vec4f>()(vec4f2, vec4f1));
+	CHECK_FALSE(std::less<Fl::Vec4f>()(vec4f1, vec4f1));
+	CHECK(std::less<Fl::Vec4f>()(vec4f1, vec4f1 + std::numeric_limits<float>::epsilon()));
+	CHECK_FALSE(std::less<Fl::Vec4f>()(vec4f1 + std::numeric_limits<float>::epsilon(), vec4f1));
+
+	CHECK(std::less<Fl::Vec3d>()(vec3d1, vec3d2));
+	CHECK_FALSE(std::less<Fl::Vec3d>()(vec3d2, vec3d1));
+	CHECK_FALSE(std::less<Fl::Vec3d>()(vec3d2, vec3d2));
+	CHECK(std::less<Fl::Vec3d>()(vec3d2, vec3d2 + std::numeric_limits<double>::epsilon()));
+	CHECK_FALSE(std::less<Fl::Vec3d>()(vec3d2 + std::numeric_limits<double>::epsilon(), vec3d2));
+}
+
+TEST_CASE("Vector: Conversion", "[Math]") {
+	CHECK(Fl::Vec3f(vec3b1) == Fl::Vec3f(31.f, 8.f, 12.f));
+	CHECK(Fl::Vec3b(vec3i1) == Fl::Vec3b(208, 0, 54)); // Values are underflowed & overflowed
+	CHECK(Fl::Vec3i(vec3f1) == Fl::Vec3i(3, 42, 0)); // Results are truncated, not rounded
+	CHECK(Fl::Vec4u(vec4f1) == Fl::Vec4u(84, 2, 0, 847));
+	CHECK(Fl::Vec4d(vec4f2) == Fl::Vec4d(13.010000228881835, 0.1500000059604644, 84.8000030517578, 72.0));
+	CHECK(Fl::Vec4f(vec4f2).StrictlyEquals(vec4f2));
+	CHECK(Fl::Vec3i(vec3d1) == Fl::Vec3i(-18, 4752, -842));
+}
+
+TEST_CASE("Vector printing", "[math]") {
+	std::stringstream stream;
+
+	stream << vec3b1;
+	CHECK(stream.str() == "[ 31, 8, 12 ]");
+
+	stream.str(std::string()); // Resetting the stream
+	stream << vec3i2;
+	CHECK(stream.str() == "[ 740, -1058, 18 ]");
+
+	stream.str(std::string());
+	stream << vec3f1;
+	CHECK(stream.str() == "[ 3.18, 42, 0.874 ]");
+
+	stream.str(std::string());
+	stream << vec3f2;
+	CHECK(stream.str() == "[ 541.41, 47.25, 6.321 ]");
+
+	stream.str(std::string());
+	stream << vec4f1;
+	CHECK(stream.str() == "[ 84.47, 2, 0.001, 847.12 ]");
+
+	stream.str(std::string());
+	stream << vec3d2;
+	CHECK(stream.str() == "[ 13.01, -1e-08, 351.025 ]");
+}

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -3,8 +3,14 @@ if has_config("build_tests") then
   
   target("FlTests")
     set_kind("binary")
-    
+
     add_files("Source/**.cpp")
+
+    for _, ext in ipairs({".hpp", ".inl"}) do
+      add_headerfiles("Include/**" .. ext)
+    end
+
+    add_includedirs("./Include")
 
     add_rpathdirs("$ORIGIN")
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -24,6 +24,8 @@ set_languages("cxx20")
 set_rundir("./bin/$(plat)_$(arch)_$(mode)")
 set_targetdir("./bin/$(plat)_$(arch)_$(mode)")
 set_warnings("allextra")
+set_allowedplats("windows", "mingw", "linux")
+set_allowedarchs("windows|x64", "mingw|x86_64", "linux|x86_64")
 add_cxflags("-Wno-missing-field-initializers -Werror=vla", {tools = {"clang", "gcc"}})
 
 option("override_runtime", {description = "Override VS runtime to MD in release and MDd in debug.", default = true})
@@ -43,8 +45,7 @@ if has_config("tracy_profiler") then
 end
 
 add_requires(
-  "spdlog",
-  "entt"
+  "spdlog"
 )
 
 target(ProjectName, function (target)
@@ -62,7 +63,6 @@ target(ProjectName, function (target)
 
   add_packages(
     "spdlog",
-    "entt",
     {public = true}
   )
 


### PR DESCRIPTION
Additions:
- Fl::Vector to represent mathematical vectors with a generic type and size.
- Fl::Matrix to represent mathematical matrices with a generic type and size.
- Fl::Quaternion to represent mathematical quaternions with a generic type.
- The Fl::MathUtils namespace contains multiple useful functions such as smoothstep, linear interpolation, etc.
- The Fl::FloatMath namespace contains functions to handle float comparisons.
- The Fl::Transform component can be used to represent an entity's transformation (translation, rotation, scale) in the world.