### PR TITLE
Added Fl::AplicationComponent.

### DIFF
--- a/Include/FlashlightEngine/Core/Application.hpp
+++ b/Include/FlashlightEngine/Core/Application.hpp
@@ -49,12 +49,46 @@ namespace Fl {
 
         /**
          * @brief Adds a component to the application.
+         * @tparam ComponentType Type of the component to add.
          * @tparam Args Types of the arguments to forward to the application component.
          * @param args Arguments to forward to the application component.
          * @return A reference to the new application component.
          */
-        template <typename... Args>
-        ApplicationComponent& AddComponent(Args&&... args);
+        template <typename ComponentType, typename... Args>
+        ComponentType& AddComponent(Args&&... args);
+
+        /**
+         * @brief Checks if a given application component is attached to the application.
+         * @tparam ComponentType Type of the component to check.
+         * @return Whether the given component is attached to the application or not.
+         */
+        template <typename ComponentType>
+        [[nodiscard]] bool HasComponent() const;
+
+        /**
+         * @brief Retrieves the component with the given type.
+         * @tparam ComponentType Type of the component to retrieve.
+         * @return A constant reference to the given component.
+         * @throws std::runtime_error If the given component isn't attached to the application.
+         */
+        template <typename ComponentType>
+		const ComponentType& GetComponent() const;
+
+        /**
+         * @brief Retrieves the component with the given type.
+         * @tparam ComponentType Type of the component to retrieve.
+         * @return A reference to the given component.
+         * @throws std::runtime_error If the given component isn't attached to the application.
+         */
+		template <typename ComponentType>
+		ComponentType& GetComponent();
+
+        /**
+         * @brief Removes the given component from the application.
+         * @tparam ComponentType Type of the component to remove.
+         */
+        template <typename ComponentType>
+		void RemoveComponent();
 
         /**
          * @brief Runs the application.

--- a/Include/FlashlightEngine/Core/Application.hpp
+++ b/Include/FlashlightEngine/Core/Application.hpp
@@ -10,6 +10,7 @@
 #include <FlashlightEngine/Prerequisites.hpp>
 
 #include <FlashlightEngine/Core/Assert.hpp>
+#include <FlashlightEngine/Core/ApplicationComponent.hpp>
 #include <FlashlightEngine/Core/World.hpp>
 #include <FlashlightEngine/DataStructures/Bitset.hpp>
 
@@ -29,6 +30,8 @@ namespace Fl {
     public:
         explicit Application(U64 worldCount = 1);
         
+        inline const std::vector<ApplicationComponentPtr>& GetAppComponents() const;
+        inline std::vector<ApplicationComponentPtr>& GetAppComponents();
         inline const std::vector<WorldPtr>& GetWorlds() const;
         inline std::vector<WorldPtr>& GetWorlds();
         inline FrameTimeInfo GetTimeInfo() const;
@@ -43,6 +46,15 @@ namespace Fl {
          */
         template <typename... Args>
         World& AddWorld(Args&&... args);
+
+        /**
+         * @brief Adds a component to the application.
+         * @tparam Args Types of the arguments to forward to the application component.
+         * @param args Arguments to forward to the application component.
+         * @return A reference to the new application component.
+         */
+        template <typename... Args>
+        ApplicationComponent& AddComponent(Args&&... args);
 
         /**
          * @brief Runs the application.
@@ -73,6 +85,9 @@ namespace Fl {
 
         std::vector<WorldPtr> m_Worlds{};
         Bitset m_ActiveWorlds{};
+
+        std::vector<ApplicationComponentPtr> m_Components{};
+        Bitset m_ActiveComponents{};
 
         FrameTimeInfo m_TimeInfo{ 0.0f, 0.0f, 0, 0.016666f };
         std::chrono::time_point<std::chrono::system_clock> m_LastFrameTime = std::chrono::system_clock::now();

--- a/Include/FlashlightEngine/Core/Application.inl
+++ b/Include/FlashlightEngine/Core/Application.inl
@@ -39,12 +39,54 @@ namespace Fl {
 		return *m_Worlds.back();
 	}
 
-	template <typename... Args>
-	ApplicationComponent& Application::AddComponent(Args&&... args) {
-		m_Components.emplace_back(std::make_unique<ApplicationComponent>(std::forward<Args>(args)...));
-		m_ActiveComponents.SetBit(m_Components.size() - 1);
+	template <typename ComponentType, typename... Args>
+	ComponentType& Application::AddComponent(Args&&... args) {
+		static_assert(std::is_base_of_v<ApplicationComponent, ComponentType>, "[Error] The application component must be derived from Fl::ApplicationComponent.");
 
-		return *m_Components.back();
+		const U64 componentId = ApplicationComponent::GetId<ComponentType>();
+
+		if (componentId >= m_Components.size()) {
+			m_Components.resize(componentId + 1);
+		}
+
+		m_Components[componentId] = std::make_unique<ComponentType>(std::forward<Args>(args)...);
+		m_ActiveComponents.SetBit(componentId);
+
+		return static_cast<ComponentType&>(*m_Components[componentId]);
+	}
+
+	template <typename ComponentType>
+	bool Application::HasComponent() const {
+		static_assert(std::is_base_of_v<ApplicationComponent, ComponentType>, "[Error] The application component must be derived from Fl::ApplicationComponent.");
+
+		const U64 componentId = ApplicationComponent::GetId<ComponentType>();
+
+		return ((componentId < m_Components.size()) && m_Components[componentId]);
+	}
+
+	template <typename ComponentType>
+	const ComponentType& Application::GetComponent() const {
+		static_assert(std::is_base_of_v<ApplicationComponent, ComponentType>, "[Error] The application component must be derived from Fl::ApplicationComponent.");
+
+		if (HasComponent<ComponentType>()) {
+			return static_cast<const ComponentType&>(*m_Components[ApplicationComponent::GetId<ComponentType>()]);
+		}
+
+		throw std::runtime_error("[Error] No component available for the given type.");
+	}
+
+	template <typename ComponentType>
+	ComponentType& Application::GetComponent() {
+		return const_cast<ComponentType&>(static_cast<const Application*>(this)->GetComponent<ComponentType>());
+	}
+
+	template <typename ComponentType>
+	void Application::RemoveComponent() {
+		static_assert(std::is_base_of_v<ApplicationComponent, ComponentType>, "[Error] The application component must be derived from Fl::ApplicationComponent.");
+
+		if (HasComponent<ComponentType>()) {
+			m_Components[ApplicationComponent::GetId<ComponentType>()].reset();
+		}
 	}
 
 	template <typename FuncType>

--- a/Include/FlashlightEngine/Core/Application.inl
+++ b/Include/FlashlightEngine/Core/Application.inl
@@ -5,6 +5,14 @@
 #pragma once
 
 namespace Fl {
+	inline const std::vector<ApplicationComponentPtr>& Application::GetAppComponents() const {
+		return m_Components;
+	}
+
+	inline std::vector<ApplicationComponentPtr>& Application::GetAppComponents() {
+		return m_Components;
+	}
+
 	inline const std::vector<WorldPtr>& Application::GetWorlds() const {
 		return m_Worlds;
 	}
@@ -29,6 +37,14 @@ namespace Fl {
 		m_ActiveWorlds.SetBit(m_Worlds.size() - 1);
 
 		return *m_Worlds.back();
+	}
+
+	template <typename... Args>
+	ApplicationComponent& Application::AddComponent(Args&&... args) {
+		m_Components.emplace_back(std::make_unique<ApplicationComponent>(std::forward<Args>(args)...));
+		m_ActiveComponents.SetBit(m_Components.size() - 1);
+
+		return *m_Components.back();
 	}
 
 	template <typename FuncType>

--- a/Include/FlashlightEngine/Core/ApplicationComponent.hpp
+++ b/Include/FlashlightEngine/Core/ApplicationComponent.hpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+#ifndef FL_CORE_APPLICATIONCOMPONENT_HPP
+#define FL_CORE_APPLICATIONCOMPONENT_HPP
+
+#include <FlashlightEngine/Prerequisites.hpp>
+
+#include <memory>
+
+namespace Fl {
+    struct FrameTimeInfo;
+
+    class ApplicationComponent;
+    using ApplicationComponentPtr = std::unique_ptr<ApplicationComponent>;
+
+    /**
+     * @brief ApplicationComponent class. Represents components that can be plugged into the application to add features to it.
+     */
+    class ApplicationComponent {
+    public:
+        /**
+         * @brief Gets the application component type's id.
+         *
+         * It uses CRTP to assign a different id to each component type it is called with.
+         * This function will be instantiated every time it is called with a different type, incrementing the assigned
+         * index.
+         * Note that it must be called directly from Fl::ApplicationComponent, and a derived class must be given
+         * (ApplicationComponent::GetId<DerivedApplicationComponent>()).
+         *
+         * @tparam AppComponentType Type of the application component to get the id from.
+         * @return The application component's id.
+         */
+        template <typename AppComponentType>
+        static U64 GetId();
+
+        /**
+         * @brief Updates the application component.
+         * @param timeInfo Time-related frame information.
+         * @return Whether the application component is still active or not.
+         */
+        inline virtual bool Update([[maybe_unused]] const FrameTimeInfo& timeInfo);
+
+        virtual ~ApplicationComponent() = default;
+
+    protected:
+		ApplicationComponent() = default;
+
+        ApplicationComponent(const ApplicationComponent&) = default;
+        ApplicationComponent(ApplicationComponent&&) noexcept = default;
+
+        ApplicationComponent& operator=(const ApplicationComponent&) = default;
+        ApplicationComponent& operator=(ApplicationComponent&&) noexcept = default;
+
+    private:
+        static inline U64 s_MaxId = 0;
+    };
+}
+
+#include <FlashlightEngine/Core/ApplicationComponent.inl>
+
+#endif // FL_CORE_APPLICATIONCOMPONENT_HPP

--- a/Include/FlashlightEngine/Core/ApplicationComponent.inl
+++ b/Include/FlashlightEngine/Core/ApplicationComponent.inl
@@ -1,0 +1,22 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier 
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+#pragma once
+
+namespace Fl {
+	template <typename AppComponentType>
+	U64 ApplicationComponent::GetId() {
+		static_assert(std::is_base_of_v<ApplicationComponent, AppComponentType>,
+			"[Error] The fetched id must be of a class derived from Fl::ApplicationComponent");
+		static_assert(!std::is_same_v<ApplicationComponent, AppComponentType>,
+			"[Error] You have to use ApplicationComponent::GetId only on a derived class and not on Fl::ApplicationComponent.");
+
+		static const U64 id = s_MaxId++;
+		return id;
+	}
+
+	inline bool ApplicationComponent::Update([[maybe_unused]] const FrameTimeInfo& timeInfo) {
+		return true;
+	}
+}

--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ depends on the main engine target, so when you will try to build the `FlTests` t
 - [ ] Model loading
 - [ ] Scripting (with Lua)
 - [ ] Audio
+- [X] Application component system to extend the Fl::Application class' features.

--- a/Source/FlashlightEngine/Core/Application.cpp
+++ b/Source/FlashlightEngine/Core/Application.cpp
@@ -47,6 +47,16 @@ namespace Fl {
             m_RemainingTime -= m_TimeInfo.SubStepTime;
         }
 
+        for (U64 componentIndex = 0; componentIndex < m_Components.size(); ++componentIndex) {
+            if (!m_ActiveComponents[componentIndex]) {
+                continue;
+            }
+
+            if (!m_Components[componentIndex]->Update(m_TimeInfo)) {
+                m_ActiveComponents.SetBit(componentIndex, false);
+            }
+        }
+
         for (U64 worldIndex = 0; worldIndex < m_Worlds.size(); ++worldIndex) {
             if (!m_ActiveWorlds[worldIndex]) {
                 continue;
@@ -60,7 +70,7 @@ namespace Fl {
 
         FL_PROFILER_FRAMEMARK;
 
-        return (m_IsRunning && !m_ActiveWorlds.IsEmpty());
+        return (m_IsRunning && !m_ActiveWorlds.IsEmpty() && !m_ActiveComponents.IsEmpty());
     }
 
     void Application::SetupLogger() {

--- a/Source/FlashlightEngine/Core/Application.cpp
+++ b/Source/FlashlightEngine/Core/Application.cpp
@@ -52,7 +52,7 @@ namespace Fl {
                 continue;
             }
 
-            if (!m_Components[componentIndex]->Update(m_TimeInfo)) {
+            if (!m_Components[componentIndex] || !m_Components[componentIndex]->Update(m_TimeInfo)) {
                 m_ActiveComponents.SetBit(componentIndex, false);
             }
         }
@@ -70,7 +70,7 @@ namespace Fl {
 
         FL_PROFILER_FRAMEMARK;
 
-        return (m_IsRunning && !m_ActiveWorlds.IsEmpty() && !m_ActiveComponents.IsEmpty());
+        return (m_IsRunning && (!m_ActiveWorlds.IsEmpty() || !m_ActiveComponents.IsEmpty()));
     }
 
     void Application::SetupLogger() {

--- a/tests/Source/Core/ApplicationComponent.cpp
+++ b/tests/Source/Core/ApplicationComponent.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 Jean "Pixfri" Letessier
+// This file is part of FlashlightEngine.
+// For conditions of distribution and use, see copyright notice in LICENSE.
+
+
+#include <FlashlightEngine/Core/Application.hpp>
+#include <FlashlightEngine/Core/ApplicationComponent.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+class TestAppComponent final : public Fl::ApplicationComponent {
+public:
+	TestAppComponent(std::size_t maxRuns) : m_MaxRuns(maxRuns) {}
+	~TestAppComponent() override = default;
+
+	bool Update([[maybe_unused]] const Fl::FrameTimeInfo& timeInfo) override {
+		UpdateCount++;
+
+		return UpdateCount < m_MaxRuns;
+	}
+
+	std::size_t UpdateCount{ 0 };
+
+private:
+	std::size_t m_MaxRuns;
+};
+
+TEST_CASE("ApplicationComponent: Application component update", "[Core]") {
+	Fl::Application testApp(0); // Do not reserve any world.
+
+	// The max update number of the component is 3.
+	auto& testAppComponent = testApp.AddComponent<TestAppComponent>(3);
+
+	CHECK(testApp.GetAppComponents().size() == Fl::ApplicationComponent::GetId<TestAppComponent>() + 1);
+
+	// This will update the application, and therefore the component only once.
+	CHECK(testApp.RunOnce());
+	CHECK(testAppComponent.UpdateCount == 1);
+
+	CHECK(testApp.RunOnce());
+	CHECK(testAppComponent.UpdateCount == 2);
+
+	// RunOnce() returns false if there is no active components and no active world anymore.
+	// Since there is no world in the first place, there is no active world, and the test components
+	// has its max update count set to 3, so it stops when it reaches the 3rd update.
+	CHECK_FALSE(testApp.RunOnce());
+	CHECK(testAppComponent.UpdateCount == 3);
+
+	// RunOnce() will still return false since there is no active component.
+	// The component will not be updated since it was considered inactive at the last update.
+	CHECK_FALSE(testApp.RunOnce());
+	CHECK(testAppComponent.UpdateCount == 3);
+}
+
+TEST_CASE("ApplicationComponent: Application component removal", "[Core]") {
+	Fl::Application testApp(0);
+
+	auto& testAppComponent = testApp.AddComponent<TestAppComponent>(2);
+
+	CHECK(testApp.RunOnce());
+	CHECK(testAppComponent.UpdateCount == 1);
+
+	CHECK(testApp.HasComponent<TestAppComponent>());
+
+	testApp.RemoveComponent<TestAppComponent>();
+
+	CHECK_FALSE(testApp.HasComponent<TestAppComponent>());
+
+	// The component is removed, and there is no more components, so RunOnce() will return false.
+	// Accessing the component isn't safe anymore since it has been released.
+	CHECK_FALSE(testApp.RunOnce());
+	CHECK(testApp.GetAppComponents().size() == Fl::ApplicationComponent::GetId<TestAppComponent>() + 1); // The memory is still reserved in case the component is added in the future.
+}
+
+TEST_CASE("ApplicationComponent: Retrieving a component", "[Core]") {
+	Fl::Application testApp(0);
+
+	// There is no world and no component, so RunOnce() will return false.
+	// Retrieving a component that is not linked to the application will throw an exception.
+	CHECK_FALSE(testApp.RunOnce());
+	CHECK_THROWS(testApp.GetComponent<TestAppComponent>());
+
+	testApp.AddComponent<TestAppComponent>(2);
+
+	CHECK(testApp.RunOnce());
+	CHECK_NOTHROW(testApp.GetComponent<TestAppComponent>());
+}


### PR DESCRIPTION
Added the Fl::ApplicationComponent base class to create application components that add functionnality to the application without dependend on worlds like systems do. 
It's used similarly to Fl::System, but they are linked to an Fl::Application instead.